### PR TITLE
Adding the possibility to run locally + refactor on runtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+#python
 __pycache__/
+#vscode
 .vscode/
+#local run files
 local*/
 /*colvar
 /energy*
@@ -7,3 +10,7 @@ local*/
 /working*
 /volume*
 /*_restraint
+/tests/*/__init__.py
+######## this is copyed from engforce.md, when they diverge THIS must be changed
+/pages/engvir.md
+########

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+.vscode/
+local*/
+/*colvar
+/energy*
+/*.xyz
+/working*
+/volume*
+/*_restraint

--- a/localrun.py
+++ b/localrun.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
     plumedToRun = [{"plumed": "plumed", "printJson": False}]
     print("Code: " + code)
     print("Preparing pages")
+    # Engforce and engvir share the same procedure
     shutil.copy("pages/engforce.md", "pages/engvir.md")
     # buildTestPages("tests/" + code, prefix, plumedToRun)
     buildTestPages("pages", prefix, plumedToRun)

--- a/localrun.py
+++ b/localrun.py
@@ -1,0 +1,39 @@
+import sys
+import getopt
+import shutil
+import importlib
+from runtests import buildTestPages, runTests
+
+
+if __name__ == "__main__":
+    code, version, argv = "", "", sys.argv[1:]
+    try:
+        opts, args = getopt.getopt(argv, "hc:v:", ["code="])
+    except:
+        print("runtests.py -c <code> -v <version>")
+
+    for opt, arg in opts:
+        if opt in ["-h"]:
+            print("runtests.py -c <code>")
+            sys.exit()
+        elif opt in ["-c", "--code"]:
+            code = arg
+        elif opt in ["-v", "--version"]:
+            version = arg
+
+    # Build all the pages that describe the tests for this code
+    buildTestPages("tests/" + code)
+    # Copy the engforce file
+    shutil.copy("pages/engforce.md", "pages/engvir.md")
+    # Build the default test pages
+    buildTestPages("pages")
+    # Create an __init__.py module for the desired code
+    ipf = open("tests/" + code + "/__init__.py", "w+")
+    ipf.write("from .mdcode import mdcode\n")
+    ipf.close()
+    # Now import the module
+    d = importlib.import_module("tests." + code, "mdcode")
+    # And create the class that interfaces with the MD code output
+    runner = d.mdcode()
+    # Now run the tests
+    runTests(code, version, runner)

--- a/localrun.py
+++ b/localrun.py
@@ -11,6 +11,15 @@ if __name__ == "__main__":
     print("Code: " + code)
     buildTestPages("tests/" + code, local, plumedToRun)
     buildTestPages("pages", local, plumedToRun)
+    # Create an __init__.py module for the desired code
+    with open("tests/" + code + "/__init__.py", "w") as ipf:
+        ipf.write("from .mdcode import mdcode\n")
+    d = importlib.import_module("tests." + code, "mdcode")
+    # And create the class that interfaces with the MD code output
+    runner = d.mdcode()
+    # Now run the tests
+    runTests(code, version, runner)
+
 if __name__ == "__main_":
     code, version, argv = "", "", sys.argv[1:]
     try:

--- a/localrun.py
+++ b/localrun.py
@@ -4,8 +4,14 @@ import shutil
 import importlib
 from runtests import buildTestPages, runTests
 
-
 if __name__ == "__main__":
+    code = "quantum_espresso"
+    local = "local_"
+    plumedToRun = [{"plumed": "plumed", "printJson": False}]
+    print("Code: " + code)
+    buildTestPages("tests/" + code, local, plumedToRun)
+    buildTestPages("pages", local, plumedToRun)
+if __name__ == "__main_":
     code, version, argv = "", "", sys.argv[1:]
     try:
         opts, args = getopt.getopt(argv, "hc:v:", ["code="])

--- a/localrun.py
+++ b/localrun.py
@@ -5,12 +5,15 @@ import importlib
 from runtests import buildTestPages, runTests
 
 if __name__ == "__main__":
+    # to run PATH must contain the dir to plumed and the one to the executable of your code
     code = "quantum_espresso"
-    local = "local_"
+    prefix = "local_"
     plumedToRun = [{"plumed": "plumed", "printJson": False}]
     print("Code: " + code)
-    buildTestPages("tests/" + code, local, plumedToRun)
-    buildTestPages("pages", local, plumedToRun)
+    print("Preparing pages")
+    shutil.copy("pages/engforce.md", "pages/engvir.md")
+    # buildTestPages("tests/" + code, prefix, plumedToRun)
+    buildTestPages("pages", prefix, plumedToRun)
     # Create an __init__.py module for the desired code
     with open("tests/" + code + "/__init__.py", "w") as ipf:
         ipf.write("from .mdcode import mdcode\n")
@@ -18,37 +21,12 @@ if __name__ == "__main__":
     # And create the class that interfaces with the MD code output
     runner = d.mdcode()
     # Now run the tests
-    runTests(code, version, runner)
-
-if __name__ == "__main_":
-    code, version, argv = "", "", sys.argv[1:]
-    try:
-        opts, args = getopt.getopt(argv, "hc:v:", ["code="])
-    except:
-        print("runtests.py -c <code> -v <version>")
-
-    for opt, arg in opts:
-        if opt in ["-h"]:
-            print("runtests.py -c <code>")
-            sys.exit()
-        elif opt in ["-c", "--code"]:
-            code = arg
-        elif opt in ["-v", "--version"]:
-            version = arg
-
-    # Build all the pages that describe the tests for this code
-    buildTestPages("tests/" + code)
-    # Copy the engforce file
-    shutil.copy("pages/engforce.md", "pages/engvir.md")
-    # Build the default test pages
-    buildTestPages("pages")
-    # Create an __init__.py module for the desired code
-    ipf = open("tests/" + code + "/__init__.py", "w+")
-    ipf.write("from .mdcode import mdcode\n")
-    ipf.close()
-    # Now import the module
-    d = importlib.import_module("tests." + code, "mdcode")
-    # And create the class that interfaces with the MD code output
-    runner = d.mdcode()
-    # Now run the tests
-    runTests(code, version, runner)
+    print("Running the tests on stable")
+    # execNameChanged=False because in my case I have compiled qe without changing its suffix
+    runTests(
+        code,
+        "stable",
+        runner,
+        prefix=prefix,
+        settigsFor_runMDCalc=dict(execNameChanged=False, makeArchive=False),
+    )

--- a/pages/cell.md
+++ b/pages/cell.md
@@ -2,7 +2,7 @@ Cell vectors are passed correctly
 ---------------------------------
 
 PLUMED must receive the cell vectors from the MD code in order to calculate CVs correctly.  
-To test these cell vectors are passed correctly to PLUMED we run a short trajectory and output the celll vectors 
+To test that cell vectors are passed correctly to PLUMED we run a short trajectory and output the cell vectors 
 that are passed to PLUMED using the following command: 
 
 ```plumed

--- a/pages/charge.md
+++ b/pages/charge.md
@@ -2,7 +2,7 @@ Charges are passed correctly
 ---------------------------
 
 PLUMED must receive the charges from an MD code in order to calculate some CVs correctly.
-To test these charges are passed correctly to PLUMED we run a short trajectory and output the charges of all the atoms that 
+To test that charges are passed correctly to PLUMED we run a short trajectory and output the charges of all the atoms that 
 are passed to PLUMED using the following command: 
 
 ```plumed

--- a/pages/energy.md
+++ b/pages/energy.md
@@ -9,8 +9,7 @@ e: ENERGY
 PRINT ARG=e FILE=colvar
 ```
 
-We can then also output the energy from the MD code and check this matches the value output by PLUMED.  We ran a short trajectory to 
-test that the energy is passed correctly.
+We can then also output the energy from the MD code and check this matches the value output by PLUMED.  We run a short trajectory to test that the energy is passed correctly.
 
 # Trajectory
 

--- a/pages/engforce.md
+++ b/pages/engforce.md
@@ -43,7 +43,7 @@ An NPT version of this calculation is performed as well as an NVT calculation if
 The table below includes some of the results from the calculation.  The columns contain:
 
 1. Time series for the energy and volume that were obtained from the simulation at $T$ K, $x_{md}$.
-2. Time series for the energy and volume that were obtained from the simulation at $\alpha T$ K and in which PLUMED applied a restriant on on the energy, $x_{pl}$.
+2. Time series for the energy and volume that were obtained from the simulation at $\alpha T$ K and in which PLUMED applied a restraint on the energy, $x_{pl}$.
 3. The absolute value of the difference between the time series of energies and volumes that were obtained from the simulations running at $T$ K and $\alpha T$ K, $\vert x_{md}'-x_{md} \vert$.  No PLUMED restraints were applied in either of these simulations.
 4. The values of $100\frac{\vert x_{md} - x_{pl}\vert }{ \vert x_{md}'-x_{md} \vert}$. 
 

--- a/pages/forces.md
+++ b/pages/forces.md
@@ -26,8 +26,8 @@ PRINT ARG=dd FILE=mdcode_restraint
 The table below includes some of the results from the calculation.  The columns contain:
 
 1. The time series of distance values that were obtained when the restraint was applied by the MD code, $x_{md}$.
-2. The time series of distance values that were obtained when the restriant was applied by PLUMED, $x_{pl}$.
-3. The tolerances that were used when comparing these quanitites, $\delta$.
+2. The time series of distance values that were obtained when the restraint was applied by PLUMED, $x_{pl}$.
+3. The tolerances that were used when comparing these quantities, $\delta$.
 4. The values of $100\frac{\vert x_{md} - x_{pl}\vert }{ \delta}$.
 
 If the PLUMED interface is working correctly the first two sets of numbers should be identical and the final column should be filled with zeros.

--- a/pages/mass.md
+++ b/pages/mass.md
@@ -2,7 +2,7 @@ Masses are passed correctly
 ---------------------------
 
 PLUMED must receive the masses from an MD code in order to calculate many CVs correctly.
-To test these masses are passed correctly to PLUMED we run a short trajectory and output the masses of all the atoms that 
+To test that masses are passed correctly to PLUMED we run a short trajectory and output the masses of all the atoms that 
 are passed to PLUMED using the following command: 
 
 ```plumed

--- a/pages/timestep.md
+++ b/pages/timestep.md
@@ -2,7 +2,7 @@ Timestep is passed correctly
 ----------------------------
 
 PLUMED must receive the timestep from an MD code in order to correctly print the times at which the CV took particular values in COLVAR files. 
-To test that the timestep is passed correctly we run a short trajectory and output the time after each sstep using the following command:
+To test that the timestep is passed correctly we run a short trajectory and output the time after each step using the following command:
 
 ```plumed
 t1: TIME

--- a/pages/virial.md
+++ b/pages/virial.md
@@ -15,7 +15,7 @@ PRINT ARG=v FILE=volume
 
 We then run a second constant pressure MD simulation at a pressure of 1001 bar and the input above.
 
-If the virial has been imlemented correctly within PLUMED the following PLUMED restraint will apply a negative pressure of 1000bar, which should compensate the fact that the
+If the virial has been implemented correctly within PLUMED the following PLUMED restraint will apply a negative pressure of 1000bar, which should compensate the fact that the
 second calculation was run at higher pressure.  We thus run a third MD calculation with the following input file:
 
 ```plumed
@@ -25,7 +25,7 @@ RESTRAINT AT=0.0 ARG=v SLOPE=-60.2214129
 PRINT ARG=v FILE=volume2
 ```
 
-The time series for the volumes that are output by the files `volume` and `volume2` above should thus be close to identicial. 
+The time series for the volumes that are output by the files `volume` and `volume2` above should thus be close to identical. 
 
 # Trajectories
 

--- a/runhelper.py
+++ b/runhelper.py
@@ -1,0 +1,180 @@
+from typing import TextIO
+import numpy as np
+
+
+def getBadge(sucess, filen, code, version: str):
+    badge = f"[![tested on {version}](https://img.shields.io/badge/{version}-"
+    if sucess < 0:
+        badge = badge + "failed-red.svg"
+    elif sucess < 5:
+        badge = badge + f"fail {sucess}%25-green.svg"
+    elif sucess < 20:
+        badge = badge + f"fail {sucess}%25-yellow.svg"
+    else:
+        badge = badge + f"fail {sucess}%25-yellow.svg"
+    return badge + f")]({filen}_{version}.html)"
+
+
+def writeReportPage(
+    filen, code, version, md_fail, zipfiles, ref, data, denom, *, prefix=""
+):
+    # Read in the file
+    with open(f"{prefix}pages/{filen}.md", "r") as f:
+        inp = f.read()
+
+    # Now output the file
+    with open(f"{prefix}tests/{code}/{filen}_{version}.md", "w+") as of:
+        for line in inp.splitlines():
+            if "Trajectory" in line and "#" in line:
+                if len(zipfiles) != 1:
+                    raise ValueError("wrong number of trajectories")
+                of.write(
+                    f"{line}\n"
+                    "Input and output files for the test calculation are available in "
+                    f"this [zip archive]({zipfiles[0]}_{version}.zip)\n\n"
+                )
+            elif "Trajectories" in line and "#" in line:
+                if len(zipfiles) == 2:
+                    of.write(
+                        f"{line}\n"
+                        "1. Input and output files for the calculation where the restraint "
+                        "is applied by the MD code available in "
+                        f"this [zip archive]({zipfiles[0]}_{version}.zip)\n"
+                        "2. Input and output files for the calculation where the restraint "
+                        "is applied by PLUMED are available in t"
+                        f"his [zip archive]({zipfiles[1]}_{version}.zip)\n\n"
+                    )
+                elif len(zipfiles) == 3:
+                    of.write(
+                        f"{line}\n"
+                        "1. Input and output files for the unpeturbed calculation "
+                        "are available in "
+                        f"this [zip archive]({zipfiles[0]}_{version}.zip)\n"
+                        "2. Input and output files for the peturbed calculation "
+                        "are available in "
+                        f"this [zip archive]({zipfiles[2]}_{version}.zip)\n\n"
+                        "3. Input and output files for the peturbed calculation in "
+                        "which a PLUMED restraint is used to undo the effect of the "
+                        "changed MD parameters are available in "
+                        f"this [zip archive]({zipfiles[1]}_{version}.zip)\n\n"
+                    )
+                else:
+                    raise ValueError("wrong number of trajectories")
+            elif "Results" in line and "#" in line and md_fail:
+                of.write(
+                    f"{line}\n"
+                    "Calculations were not sucessful and no data was generated for comparison\n"
+                )
+            else:
+                of.write(line + "\n")
+        if not md_fail and hasattr(data, "__len__"):
+            if len(zipfiles) == 1:
+                of.write(
+                    "\n| MD code output | PLUMED output | Tolerance | % Difference | \n"
+                )
+            else:
+                of.write(
+                    "\n| Original result | Result with PLUMED | Effect of peturbation | % Difference | \n"
+                )
+            of.write(
+                "|:-------------|:--------------|:--------------|:--------------| \n"
+            )
+            nlines = min(20, len(ref))
+            percent_diff = 100 * np.divide(
+                np.abs(ref - data), denom, out=np.zeros_like(denom), where=denom != 0
+            )
+            for i in range(nlines):
+                if hasattr(ref[i], "__len__"):
+                    ref_strings = " ".join([f"{x:.4f}" for x in ref[i]])
+                    data_strings = " ".join([f"{x:.4f}" for x in data[i]])
+                    denom_strings = " ".join([f"{x:.4f}" for x in denom[i]])
+                    pp_strings = " ".join([f"{x:.4f}" for x in percent_diff[i]])
+                    of.write(
+                        f"| {ref_strings} | {data_strings} | {denom_strings} | {pp_strings} | \n"
+                    )
+                else:
+                    # TODO:ask if also this needs formatting (just append ":.4f")
+                    of.write(
+                        f"| {ref[i]} | {data[i]} | {denom[i]} | {percent_diff[i]} |\n"
+                    )
+        elif not md_fail:
+            if len(zipfiles) == 1:
+                of.write(
+                    "\n| MD code output | PLUMED output | Tolerance | % Difference | \n"
+                )
+            else:
+                of.write(
+                    "| Original result | Result with PLUMED | Effect of peturbation | % Difference | \n"
+                )
+            of.write(
+                "|:-------------|:--------------|:--------------|:--------------| \n"
+                f"| {ref} | {data} | {denom} | {100 * np.abs(ref - data) / denom} | \n"
+            )
+
+
+def check(md_failed: "int|bool", val1, val2, val3, tolerance: float = 0.0) -> int:
+    # this may be part of writeReportForSimulations
+    if md_failed:
+        return -1
+    if hasattr(val2, "__len__") and len(val1) != len(val2):
+        return -1
+    if hasattr(val2, "__len__") and len(val3) != len(val2):
+        return -1
+    percent_diff = 100 * np.divide(
+        np.abs(val1 - val2), val3, out=np.zeros_like(val3), where=val3 > tolerance
+    )
+    return int(np.round(np.average(percent_diff)))
+
+
+class writeReportForSimulations:
+    """helper class to write the report tof the simulations"""
+
+    def __init__(
+        self,
+        testout: TextIO,
+        code: str,
+        version: str,
+        md_failed,
+        simulations,
+        *,
+        prefix="",
+    ) -> None:
+        # note that the prefix cannot accidentally be set, because it must explicitly named to be set
+        self.testout = testout
+        self.code = code
+        self.version = version
+        self.md_failed = md_failed
+        self.simulations = simulations
+        self.prefix = prefix
+
+    def writeReportAndTable(
+        self,
+        kind: str,
+        docstring: str,
+        val1,
+        val2,
+        val3,
+        *,
+        tolerance: float = 0.0,
+    ):
+        writeReportPage(
+            kind,
+            self.code,
+            self.version,
+            self.md_failed,
+            self.simulations,
+            val1,
+            val2,
+            val3,
+            prefix=self.prefix,
+        )
+        self.testout.write(
+            f"| {docstring} | "
+            + getBadge(
+                check(self.md_failed, val1, val2, val3, tolerance=tolerance),
+                kind,
+                self.code,
+                self.version,
+            )
+            + " |\n"
+        )

--- a/runhelper.py
+++ b/runhelper.py
@@ -5,13 +5,17 @@ import numpy as np
 def getBadge(sucess, filen, code, version: str):
     badge = f"[![tested on {version}](https://img.shields.io/badge/{version}-"
     if sucess < 0:
-        badge = badge + "failed-red.svg"
-    elif sucess < 5:
-        badge = badge + f"fail {sucess}%25-green.svg"
-    elif sucess < 20:
-        badge = badge + f"fail {sucess}%25-yellow.svg"
+        badge += "failed-red.svg"
     else:
-        badge = badge + f"fail {sucess}%25-yellow.svg"
+        color = "red"
+        if sucess < 5:
+            color = "green"
+        elif sucess < 20:
+            color = "yellow"
+        else:
+            # shoudn't this be red?
+            color = "yellow"
+        badge += f"fail%20{sucess}%25-{color}.svg"
     return badge + f")]({filen}_{version}.html)"
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -140,6 +140,7 @@ def runMDCalc(
 
     # Now test that the executable exists if it doesn't then the test is broken
     if shutil.which(params["executible"]) == None:
+        print(f"Executable {params['executible']} does not exist in current PATH.")
         return True
     # Copy all the input needed for the MD calculation
     wdir = f"{basedir}/{name}_{version}"

--- a/runtests.py
+++ b/runtests.py
@@ -11,6 +11,7 @@ from datetime import date
 from contextlib import contextmanager
 from PlumedToHTML import test_plumed, get_html
 
+
 @contextmanager
 def cd(newdir):
     prevdir = os.getcwd()
@@ -20,324 +21,845 @@ def cd(newdir):
     finally:
         os.chdir(prevdir)
 
-def processMarkdown( filename ) :
-    if not os.path.exists(filename) :
-       raise RuntimeError("Found no file called " + filename )
-    f = open( filename, "r" )
+
+def processMarkdown(filename):
+    if not os.path.exists(filename):
+        raise RuntimeError("Found no file called " + filename)
+    f = open(filename, "r")
     inp = f.read()
     f.close()
-    ofile, inplumed, plumed_inp, ninputs = open( filename, "w+" ), False, "", 0
-    for line in inp.splitlines() :
-        # Detect and copy plumed input files 
-        if "```plumed" in line :
-           inplumed, plumed_inp, ninputs = True, "", ninputs + 1
-        # Test plumed input files that have been found in tutorial 
-        elif inplumed and "```" in line :
-           inplumed = False
-           solutionfile = "working" + str(ninputs) + ".dat"
-           sf = open( solutionfile, "w+" )
-           sf.write( plumed_inp )
-           sf.close()
-           # Test whether the input solution can be parsed
-           success = success=test_plumed( "plumed", solutionfile )
-           success_master=test_plumed( "plumed_master", solutionfile, printjson=True  )
-           # Find the stable version 
-           stable_version=subprocess.check_output('plumed info --version', shell=True).decode('utf-8').strip()
-           # Use PlumedToHTML to create the input with all the bells and whistles
-           html = get_html( plumed_inp, solutionfile, solutionfile, ("v"+ stable_version,"master"), (success,success_master), ("plumed","plumed_master"), usejson=(not success_master) )
-           # Print the html for the solution
-           ofile.write( "{% raw %}\n" + html + "\n {% endraw %} \n" )
-        elif inplumed :
-             if "__FILL__" in line : raise RuntimeError("Should not be incomplete files in this page")
-             plumed_inp += line + "\n"
+    ofile, inplumed, plumed_inp, ninputs = open(filename, "w+"), False, "", 0
+    for line in inp.splitlines():
+        # Detect and copy plumed input files
+        if "```plumed" in line:
+            inplumed, plumed_inp, ninputs = True, "", ninputs + 1
+        # Test plumed input files that have been found in tutorial
+        elif inplumed and "```" in line:
+            inplumed = False
+            solutionfile = "working" + str(ninputs) + ".dat"
+            sf = open(solutionfile, "w+")
+            sf.write(plumed_inp)
+            sf.close()
+            # Test whether the input solution can be parsed
+            success = success = test_plumed("plumed", solutionfile)
+            success_master = test_plumed("plumed_master", solutionfile, printjson=True)
+            # Find the stable version
+            stable_version = (
+                subprocess.check_output("plumed info --version", shell=True)
+                .decode("utf-8")
+                .strip()
+            )
+            # Use PlumedToHTML to create the input with all the bells and whistles
+            html = get_html(
+                plumed_inp,
+                solutionfile,
+                solutionfile,
+                ("v" + stable_version, "master"),
+                (success, success_master),
+                ("plumed", "plumed_master"),
+                usejson=(not success_master),
+            )
+            # Print the html for the solution
+            ofile.write("{% raw %}\n" + html + "\n {% endraw %} \n")
+        elif inplumed:
+            if "__FILL__" in line:
+                raise RuntimeError("Should not be incomplete files in this page")
+            plumed_inp += line + "\n"
         # Just copy any line that isn't part of a plumed input
-        elif not inplumed : ofile.write( line + "\n" )
+        elif not inplumed:
+            ofile.write(line + "\n")
     ofile.close()
 
-def buildTestPages( directory ) :
-   for page in os.listdir(directory) :
-       if ".md" in page : processMarkdown( directory + "/" + page )
 
-def runMDCalc( name, code, version, runner, params ) :
+def buildTestPages(directory):
+    for page in os.listdir(directory):
+        if ".md" in page:
+            processMarkdown(directory + "/" + page)
+
+
+def runMDCalc(name, code, version, runner, params):
     # Get the name of the executible
-    stram=open("tests/" + code + "/info.yml", "r") 
-    params["executible"]=yaml.load(stram,Loader=yaml.BaseLoader)["executible"] + "_" + version
+    stram = open("tests/" + code + "/info.yml", "r")
+    params["executible"] = (
+        yaml.load(stram, Loader=yaml.BaseLoader)["executible"] + "_" + version
+    )
     stram.close()
     # Now test that the executable exists if it doesn't then the test is broken
-    if shutil.which(params["executible"]) == None : return True
+    if shutil.which(params["executible"]) == None:
+        return True
     # Copy all the input needed for the MD calculation
-    shutil.copytree("tests/" + code + "/input", "tests/" + code + "/" + name + "_" + version ) 
+    shutil.copytree(
+        "tests/" + code + "/input", "tests/" + code + "/" + name + "_" + version
+    )
     # Change to the directory to run the calculation
-    with cd("tests/" + code + "/" + name + "_" + version ) :
-       # Output the plumed file  
-       of = open("plumed.dat","w+")
-       of.write(params["plumed"])
-       of.close() 
-       # Now run the MD calculation
-       broken = runner.runMD( params )
+    with cd("tests/" + code + "/" + name + "_" + version):
+        # Output the plumed file
+        of = open("plumed.dat", "w+")
+        of.write(params["plumed"])
+        of.close()
+        # Now run the MD calculation
+        broken = runner.runMD(params)
     # Make a zip archive that contains the input and output
-    shutil.make_archive("tests/" + code + "/" + name + "_" + version, 'zip', "tests/" + code + "/" + name + "_" + version )
+    shutil.make_archive(
+        "tests/" + code + "/" + name + "_" + version,
+        "zip",
+        "tests/" + code + "/" + name + "_" + version,
+    )
     return broken
 
-def runTests(code,version,runner) :
-   # Read in the information on the tests that should be run for this code
-   stram=open("tests/" + code + "/info.yml", "r")
-   ymldata = yaml.load(stram,Loader=yaml.BaseLoader)
-   info, tolerance = ymldata["tests"], float( ymldata["tolerance"] )
-   stram.close()
 
-   fname, usestable = "testout.md", version=="stable"
-   if version=="master" : fname = "testout_" + version + ".md"
-   elif version!="stable" : ValueError("version should be master or stable")
+def runTests(code, version, runner):
+    # Read in the information on the tests that should be run for this code
+    stram = open("tests/" + code + "/info.yml", "r")
+    ymldata = yaml.load(stram, Loader=yaml.BaseLoader)
+    info, tolerance = ymldata["tests"], float(ymldata["tolerance"])
+    stram.close()
 
-   of = open("tests/" + code + "/" + fname, "w+")
-   of.write("Testing " + code + "\n")
-   of.write("------------------------\n \n")
-   stable_version=subprocess.check_output('plumed info --version', shell=True).decode('utf-8').strip()
-   of.write("The tests described in the following table were performed on __" + date.today().strftime("%B %d, %Y") + "__ to test whether the interface between " + code + " and ")
-   if version=="stable" : version = "v" + stable_version
-   of.write("the " + version + " version of PLUMED is working correctly.\n\n") 
-   if info["virial"]=="no" : of.write("WARNING: " + code + " does not pass the virial to PLUMED and it is thus not possible to run NPT simulations with this code\n\n")
-   if "warning" in ymldata.keys() : 
-      for warn in ymldata["warning"] : of.write("WARNING: " + warn + "\n\n")
+    fname, usestable = "testout.md", version == "stable"
+    if version == "master":
+        fname = "testout_" + version + ".md"
+    elif version != "stable":
+        ValueError("version should be master or stable")
 
-   params, basic_md_failed = runner.setParams(), True
-   if info["positions"]=="yes" or info["timestep"]=="yes" or info["mass"]=="yes" or info["charge"]=="yes" : 
-      params["plumed"] = "DUMPATOMS ATOMS=@mdatoms FILE=plumed.xyz\n"
-      params["plumed"] = params["plumed"] + "c: CELL \n PRINT ARG=c.* FILE=cell_data\n"
-      if info["mass"]=="yes" and info["charge"]=="yes" : params["plumed"] = params["plumed"] + "DUMPMASSCHARGE FILE=mq_plumed\n"
-      elif info["mass"]=="yes" : params["plumed"] = params["plumed"] + "DUMPMASSCHARGE FILE=mq_plumed ONLY_MASSES\n"
-      if info["timestep"]=="yes" : params["plumed"] = params["plumed"] + "t1: TIME\nPRINT ARG=t1 FILE=colvar\n"
-      params["nsteps"], params["ensemble"] = 10, "npt"
-      basic_md_failed = runMDCalc( "basic", code, version, runner, params )
-  
-   val1, val2 = 0.1, 0.1  
-   of.write("| Description of test | Status | \n")
-   of.write("|:--------------------|:------:| \n")
-   if info["positions"]=="yes" :
-      plumednatoms, codenatoms, codepos, plumedpos, codecell, plumedcell = [], [], np.ones(10), np.ones(10), np.ones(10), np.ones(10)
-      if not basic_md_failed :
-         # Get the trajectory that was output by PLUMED
-         if os.path.exists("tests/" + code + "/basic_" + version + "/plumed.xyz") : 
-            plumedtraj = mda.coordinates.XYZ.XYZReader("tests/" + code + "/basic_" + version + "/plumed.xyz")
-            # Get the number of atoms in each frame from plumed trajectory
-            plumednatoms, codenatoms = [], runner.getNumberOfAtoms( "tests/" + code + "/basic_" + version )
-            for frame in plumedtraj.trajectory : plumednatoms.append( frame.positions.shape[0] )
-            # Concatenate all the trajectory frames
-            codepos, first = runner.getPositions( "tests/" + code + "/basic_" + version ), True
-            for frame in plumedtraj.trajectory :
-                if first : plumedpos, first = frame.positions.copy(), False
-                else : plumedpos = np.concatenate( (plumedpos, frame.positions), axis=0 )
-            codecell, plumedcell = runner.getCell( "tests/" + code + "/basic_" + version ), np.loadtxt("tests/" + code + "/basic_" + version + "/cell_data")[:,1:]
-         else : basic_md_failed = True
+    of = open("tests/" + code + "/" + fname, "w+")
+    of.write("Testing " + code + "\n")
+    of.write("------------------------\n \n")
+    stable_version = (
+        subprocess.check_output("plumed info --version", shell=True)
+        .decode("utf-8")
+        .strip()
+    )
+    of.write(
+        "The tests described in the following table were performed on __"
+        + date.today().strftime("%B %d, %Y")
+        + "__ to test whether the interface between "
+        + code
+        + " and "
+    )
+    if version == "stable":
+        version = "v" + stable_version
+    of.write("the " + version + " version of PLUMED is working correctly.\n\n")
+    if info["virial"] == "no":
+        of.write(
+            "WARNING: "
+            + code
+            + " does not pass the virial to PLUMED and it is thus not possible to run NPT simulations with this code\n\n"
+        )
+    if "warning" in ymldata.keys():
+        for warn in ymldata["warning"]:
+            of.write("WARNING: " + warn + "\n\n")
 
-      # Output results from tests on natoms
-      writeReportPage( "natoms", code, version, basic_md_failed, ["basic"], np.array(codenatoms), np.array(plumednatoms), 0.01*np.ones(len(codenatoms)) ) 
-      of.write("| MD code number of atoms passed correctly | " + getBadge( check(basic_md_failed, np.array(codenatoms), np.array(plumednatoms), 0.01*np.ones(len(codenatoms)), 0 ), "natoms", code, version) + "| \n") 
-      # Output results from tests on positions
-      writeReportPage( "positions", code, version, basic_md_failed, ["basic"], np.array(codepos), plumedpos, tolerance*np.ones(plumedpos.shape) )
-      of.write("| MD code positions passed correctly | " + getBadge( check(basic_md_failed, np.array(codepos), plumedpos, tolerance*np.ones(plumedpos.shape), 0 ), "positions", code, version) + "| \n")
-      writeReportPage( "cell", code, version, basic_md_failed, ["basic"], np.array(codecell), plumedcell, tolerance*np.ones(plumedcell.shape) )
-      of.write("| MD code cell vectors passed correctly | " + getBadge( check(basic_md_failed, np.array(codecell), plumedcell, tolerance*np.ones(plumedcell.shape), 0 ), "cell", code, version) + " | \n")
-   if info["timestep"]=="yes" :
-      md_tstep, plumed_tstep = 0.1, 0.1
-      if not basic_md_failed :
-         plumedtimes = np.loadtxt("tests/" + code + "/basic_" + version + "/colvar")[:,1]
-         md_tstep, plumed_tstep = runner.getTimestep(), plumedtimes[1]-plumedtimes[0]
-         for i in range(1,len(plumedtimes)) : 
-             if plumedtimes[i]-plumedtimes[i-1]!=plumed_tstep : ValueError("Timestep should be the same for all MD steps")
-      writeReportPage( "timestep", code, version, basic_md_failed, ["basic"], md_tstep, plumed_tstep, 0.0001 )
-      of.write("| MD timestep passed correctly | " + getBadge( check(basic_md_failed, md_tstep, plumed_tstep, 0.0001, 0 ), "timestep", code, version) + " | \n")
-   if info["mass"]=="yes" : 
-      md_masses, pl_masses = np.ones(10), np.ones(10)
-      if not basic_md_failed : md_masses, pl_masses = runner.getMasses("tests/" + code + "/basic_" + version), np.loadtxt("tests/" + code + "/basic_" + version + "/mq_plumed")[:,1]
-      writeReportPage( "mass", code, version, basic_md_failed, ["basic"], np.array(md_masses), pl_masses, tolerance*np.ones(pl_masses.shape) ) 
-      of.write("| MD code masses passed correctly | " + getBadge( check( basic_md_failed, np.array(md_masses), pl_masses, tolerance*np.ones(pl_masses.shape), 0 ), "mass", code, version) + " | \n")
-   if info["charge"]=="yes" :
-      md_charges, pl_charges = np.ones(10), np.ones(10)
-      if not basic_md_failed : md_charges, pl_charges = runner.getCharges("tests/" + code + "/basic_" + version), np.loadtxt("tests/" + code + "/basic_" + version + "/mq_plumed")[:,2]
-      writeReportPage( "charge", code, version, basic_md_failed, ["basic"], np.array(md_charges), pl_charges, tolerance*np.ones(pl_charges.shape) ) 
-      of.write("| MD code charges passed correctly | " + getBadge( check( basic_md_failed, np.array(md_charges), pl_charges, tolerance*np.ones(pl_charges.shape), 0 ), "charge", code, version) + " | \n")
-   if info["forces"]=="yes" :
-      # First run a calculation to find the reference distance between atom 1 and 2
-      rparams = runner.setParams()
-      rparams["nsteps"], rparams["ensemble"] = 2, "nvt"
-      rparams["plumed"] = "dd: DISTANCE ATOMS=1,2 \nPRINT ARG=dd FILE=colvar"
-      refrun, mdrun, plrun = runMDCalc("refres", code, version, runner, rparams ), True, True
-      if not refrun : 
-         # Get the reference distance betwene the atoms
-         refdist = np.loadtxt("tests/" + code + "/refres_" + version + "/colvar")[0,1]
-         # Run the calculation with the restraint applied by the MD code
-         rparams["nsteps"], rparams["ensemble"] = 20, "nvt"
-         rparams["restraint"] = refdist
-         rparams["plumed"] = "dd: DISTANCE ATOMS=1,2 \nPRINT ARG=dd FILE=colvar"
-         mdrun = runMDCalc("forces1", code, version, runner, rparams )
-         # Run the calculation with the restraint applied by PLUMED
-         rparams["restraint"] = -10
-         rparams["plumed"] = "dd: DISTANCE ATOMS=1,2 \nRESTRAINT ARG=dd KAPPA=2000 AT=" + str(refdist) + "\nPRINT ARG=dd FILE=colvar"
-         plrun = runMDCalc("forces2", code, version, runner, rparams )
-      # And create our reports from the two runs
-      md_failed, val1, val2 = mdrun or plrun, np.ones(1), np.ones(1) 
-      if not md_failed : val1, val2 = np.loadtxt("tests/" + code + "/forces1_" + version + "/colvar")[:,1], np.loadtxt("tests/" + code + "/forces2_" + version + "/colvar")[:,1]
-      writeReportPage( "forces", code, version, md_failed, ["forces1", "forces2"], val1, val2, tolerance*np.ones(val1.shape) )
-      of.write("| PLUMED forces passed correctly | " + getBadge( check( md_failed, val1, val2, tolerance*np.ones(val1.shape), tolerance ), "forces", code, version) + " | \n")
-   if info["virial"]=="yes" :
-      params = runner.setParams()
-      params["nsteps"], params["ensemble"] = 50, "npt"
-      params["plumed"] = "vv: VOLUME \n PRINT ARG=vv FILE=volume"
-      run1 = runMDCalc("virial1", code, version, runner, params )
-      params["pressure"] = 1001*params["pressure"] 
-      run3 = runMDCalc("virial3", code, version, runner, params )
-      params["plumed"] = "vv: VOLUME \n RESTRAINT AT=0.0 ARG=vv SLOPE=-60.221429 \nPRINT ARG=vv FILE=volume"
-      run2 = runMDCalc("virial2", code, version, runner, params )
-      md_failed, val1, val2, val3 = run1 or run2 or run3, np.ones(1), np.ones(1), np.ones(1)
-      if not md_failed : val1, val2, val3 = np.loadtxt("tests/" + code + "/virial1_" + version + "/volume")[:,1], np.loadtxt("tests/" + code + "/virial2_" + version + "/volume")[:,1], np.loadtxt("tests/" + code + "/virial3_" + version + "/volume")[:,1]
-      writeReportPage( "virial", code, version, md_failed, ["virial1", "virial2", "virial3"], val1, val2, np.abs(val3-val1) )
-      of.write("| PLUMED virial passed correctly | " + getBadge( check( md_failed, val1, val2, np.abs(val3-val1), tolerance ), "virial", code, version) + " | \n")
-   if info["energy"]=="yes" :
-      params["nsteps"], params["plumed"] = 150, "e: ENERGY \nPRINT ARG=e FILE=energy"
-      md_failed, md_energy, pl_energy = runMDCalc( "energy", code, version, runner, params ), np.ones(1), np.ones(1) 
-      if not md_failed and os.path.exists("tests/" + code + "/energy_" + version + "/energy") : md_energy, pl_energy = runner.getEnergy("tests/" + code + "/energy_" + version), np.loadtxt("tests/" + code + "/energy_" + version + "/energy")[:,1]
-      else : md_failed = True
-      writeReportPage( "energy", code, version, md_failed, ["energy"], md_energy, pl_energy, tolerance*np.ones(len(md_energy)) )
-      of.write("| MD code potential energy passed correctly | " + getBadge( check( md_failed, md_energy, pl_energy, tolerance*np.ones(len(md_energy)), tolerance ), "energy", code, version) + " | \n") 
-      sqrtalpha = 1.1
-      alpha = sqrtalpha*sqrtalpha
-      if info["engforces"]=="yes" :
-         params = runner.setParams()
-         params["nsteps"], params["ensemble"] = 50, "nvt"
-         params["plumed"] = "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy"
-         run1 = runMDCalc("engforce1", code, version, runner, params )
-         params["temperature"] = params["temperature"]*alpha
-         params["relaxtime"] = params["relaxtime"] / sqrtalpha
-         params["tstep"] = params["tstep"] / sqrtalpha
-         run3 = runMDCalc("engforce3", code, version, runner, params )
-         params["plumed"] = "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy \n RESTRAINT AT=0.0 ARG=e SLOPE=" + str(alpha - 1)
-         run2 = runMDCalc("engforce2", code, version, runner, params )
-         md_failed, val1, val2, val3 = run1 or run2 or run3, np.ones(1), np.ones(1), np.ones(1)
-         if not md_failed : val1, val2, val3 = np.loadtxt("tests/" + code + "/engforce1_" + version + "/energy")[:,1:], np.loadtxt("tests/" + code + "/engforce2_" + version + "/energy")[:,1:], np.loadtxt("tests/" + code + "/engforce3_" + version + "/energy")[:,1:]
-         writeReportPage( "engforce", code, version, md_failed, ["engforce1", "engforce2", "engforce3"], val1, val2, np.abs(val1-val3) ) 
-         of.write("| PLUMED forces on potential energy passed correctly | " + getBadge( check( md_failed, val1, val2, np.abs(val1-val3), tolerance ), "engforce", code, version) + " | \n") 
-      if info["engforces"] and info["virial"]=="yes" :
-         params = runner.setParams()
-         params["nsteps"], params["ensemble"] = 150, "npt"
-         params["plumed"] = "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy"
-         run1 = runMDCalc("engvir1", code, version, runner, params )
-         params["temperature"] = params["temperature"]*alpha
-         params["relaxtime"], params["prelaxtime"] = params["relaxtime"] / sqrtalpha, params["prelaxtime"] / sqrtalpha
-         params["tstep"] = params["tstep"] / sqrtalpha
-         run3 = runMDCalc("engvir3", code, version, runner, params )
-         params["plumed"] = "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy \n RESTRAINT AT=0.0 ARG=e SLOPE=" + str(alpha - 1)
-         run2 = runMDCalc("engvir2", code, version, runner, params )
-         md_failed, val1, val2, val3 = run1 or run2 or run3, np.ones(1), np.ones(1), np.ones(1)
-         if not md_failed : val1, val2, val3 = np.loadtxt("tests/" + code + "/engvir1_" + version + "/energy")[:,1:], np.loadtxt("tests/" + code + "/engvir2_" + version + "/energy")[:,1:], np.loadtxt("tests/" + code + "/engvir3_" + version + "/energy")[:,1:]
-         writeReportPage( "engvir", code, version, md_failed, ["engvir1", "engvir2", "engvir3"], val1, val2, np.abs(val1-val3) )
-         of.write("| PLUMED contribution to virial due to force on potential energy passed correctly | " + getBadge( check( md_failed, val1, val2, np.abs(val1-val3), tolerance ), "engvir", code, version) + " | \n") 
-   of.close()
-   # Read output file to get status
-   ifn, of = open("tests/" + code + "/" + fname, "r"), open("tests/" + code + "/info.yml", "a")
-   inp = ifn.read()
-   ifn.close()
-   if "failed-red.svg" in inp : of.write("test_plumed" + version + ": broken \n")
-   elif "%25-green.svg" in inp and ("%25-red.svg" in inp or "%25-yellow.svg" in inp) : of.write("test_plumed" + version + ": partial\n")
-   elif "%25-yellow.svg" in inp : of.write("test_plumed" + version + ": partial\n")
-   elif "%25-green.svg" in inp : of.write("test_plumed" + version + ": working \n")
-   elif "%25-red.svg" in inp : of.write("test_plumed" + version + ": broken \n")
-   else : raise Exception("Found no test badges in output for tests on " + code + " with " + version)
-   of.close()
+    params, basic_md_failed = runner.setParams(), True
+    if (
+        info["positions"] == "yes"
+        or info["timestep"] == "yes"
+        or info["mass"] == "yes"
+        or info["charge"] == "yes"
+    ):
+        params["plumed"] = "DUMPATOMS ATOMS=@mdatoms FILE=plumed.xyz\n"
+        params["plumed"] = (
+            params["plumed"] + "c: CELL \n PRINT ARG=c.* FILE=cell_data\n"
+        )
+        if info["mass"] == "yes" and info["charge"] == "yes":
+            params["plumed"] = params["plumed"] + "DUMPMASSCHARGE FILE=mq_plumed\n"
+        elif info["mass"] == "yes":
+            params["plumed"] = (
+                params["plumed"] + "DUMPMASSCHARGE FILE=mq_plumed ONLY_MASSES\n"
+            )
+        if info["timestep"] == "yes":
+            params["plumed"] = params["plumed"] + "t1: TIME\nPRINT ARG=t1 FILE=colvar\n"
+        params["nsteps"], params["ensemble"] = 10, "npt"
+        basic_md_failed = runMDCalc("basic", code, version, runner, params)
 
-def getBadge( sucess, filen, code, version ) :
-   badge = '[![tested on ' + version + '](https://img.shields.io/badge/' + version + '-'
-   if sucess<0 : badge = badge + 'failed-red.svg'
-   elif sucess<5 : badge = badge + 'fail ' + str(sucess) + '%25-green.svg'
-   elif sucess<20 : badge = badge + 'fail ' + str(sucess) + '%25-yellow.svg'
-   else : badge = badge + 'fail ' + str(sucess) + '%25-yellow.svg'
-   return badge + ')](' + filen + '_' + version + '.html)'
+    val1, val2 = 0.1, 0.1
+    of.write("| Description of test | Status | \n")
+    of.write("|:--------------------|:------:| \n")
+    if info["positions"] == "yes":
+        plumednatoms, codenatoms, codepos, plumedpos, codecell, plumedcell = (
+            [],
+            [],
+            np.ones(10),
+            np.ones(10),
+            np.ones(10),
+            np.ones(10),
+        )
+        if not basic_md_failed:
+            # Get the trajectory that was output by PLUMED
+            if os.path.exists("tests/" + code + "/basic_" + version + "/plumed.xyz"):
+                plumedtraj = mda.coordinates.XYZ.XYZReader(
+                    "tests/" + code + "/basic_" + version + "/plumed.xyz"
+                )
+                # Get the number of atoms in each frame from plumed trajectory
+                plumednatoms, codenatoms = [], runner.getNumberOfAtoms(
+                    "tests/" + code + "/basic_" + version
+                )
+                for frame in plumedtraj.trajectory:
+                    plumednatoms.append(frame.positions.shape[0])
+                # Concatenate all the trajectory frames
+                codepos, first = (
+                    runner.getPositions("tests/" + code + "/basic_" + version),
+                    True,
+                )
+                for frame in plumedtraj.trajectory:
+                    if first:
+                        plumedpos, first = frame.positions.copy(), False
+                    else:
+                        plumedpos = np.concatenate((plumedpos, frame.positions), axis=0)
+                codecell, plumedcell = (
+                    runner.getCell("tests/" + code + "/basic_" + version),
+                    np.loadtxt("tests/" + code + "/basic_" + version + "/cell_data")[
+                        :, 1:
+                    ],
+                )
+            else:
+                basic_md_failed = True
 
-def writeReportPage( filen, code, version, md_fail, zipfiles, ref, data, denom ) :
-   # Read in the file
-   f = open( "pages/" + filen + ".md", "r" )
-   inp = f.read()
-   f.close()
-   # Now output the file 
-   of = open("tests/" + code + "/" + filen + "_" + version + ".md", "w+" )
-   for line in inp.splitlines() :
-       if "Trajectory" in line and "#" in line : 
-           if len(zipfiles)!=1 : raise ValueError("wrong number of trajectories")
-           of.write(line + "\n")
-           of.write("Input and output files for the test calculation are available in this [zip archive](" + zipfiles[0] + "_" + version + ".zip) \n\n")
-       elif "Trajectories" in line and "#" in line :
-           if len(zipfiles)==2 : 
-              of.write(line + "\n")
-              of.write("1. Input and output files for the calculation where the restraint is applied by the MD code available in this [zip archive](" + zipfiles[0] + "_" + version + ".zip) \n")
-              of.write("2. Input and output files for the calculation where the restraint is applied by PLUMED are available in this [zip archive](" + zipfiles[1] + "_" + version + ".zip) \n\n") 
-           elif len(zipfiles)==3 : 
-              of.write(line + "\n")
-              of.write("1. Input and output files for the unpeturbed calculation are available in this [zip archive](" + zipfiles[0] + "_" + version + ".zip) \n")
-              of.write("2. Input and output files for the peturbed calculation are available in this [zip archive](" + zipfiles[2] + "_" + version + ".zip) \n\n")
-              of.write("2. Input and output files for the peturbed calculation in which a PLUMED restraint is used to undo the effect of the changed MD parameters are available in this [zip archive](" + zipfiles[1] + "_" + version + ".zip) \n\n")
-           else : raise ValueError("wrong number of trajectories")
-       elif "Results" in line and "#" in line and md_fail :
-           of.write(line + "\n")
-           of.write("Calculations were not sucessful and no data was generated for comparison\n")  
-       else : of.write(line + "\n")
-   if not md_fail and hasattr(data, "__len__") : 
-      if len(zipfiles)==1 : of.write("\n| MD code output | PLUMED output | Tolerance | % Difference | \n")
-      else : of.write("\n| Original result | Result with PLUMED | Effect of peturbation | % Difference | \n")
-      of.write("|:-------------|:--------------|:--------------|:--------------| \n")
-      nlines = min( 20, len(ref) )
-      percent_diff = 100*np.divide( np.abs( ref - data ), denom, out=np.zeros_like(denom), where=denom!=0 )
-      for i in range(nlines) : 
-          if hasattr(ref[i], "__len__") :
-             ref_strings = [ "%.4f" % x for x in ref[i] ] 
-             data_strings = [ "%.4f" % x for x in data[i] ]
-             denom_strings = [ "%.4f" % x for x in denom[i] ]
-             pp_strings = [ "%.4f" % x for x in percent_diff[i] ]
-             of.write("|" + " ".join(ref_strings) + " | " + " ".join(data_strings) + " | " + " ".join(denom_strings) + " | " + " ".join(pp_strings) + "| \n")
-          else : of.write("|" + str(ref[i]) + " | " + str(data[i]) + " | " + str(denom[i]) + " | " + str(percent_diff[i]) + "| \n")
-   elif not md_fail : 
-      if len(zipfiles)==1 : of.write("\n| MD code output | PLUMED output | Tolerance | % Difference | \n")
-      else : of.write("| Original result | Result with PLUMED | Effect of peturbation | % Difference | \n")
-      of.write("|:-------------|:--------------|:--------------|:--------------| \n")
-      of.write("| " + str(ref) + " | " + str(data) + " | " + str(denom) + " | " + str(100*np.abs(ref-data)/denom) + " | \n")
-   of.close()
+        # Output results from tests on natoms
+        writeReportPage(
+            "natoms",
+            code,
+            version,
+            basic_md_failed,
+            ["basic"],
+            np.array(codenatoms),
+            np.array(plumednatoms),
+            0.01 * np.ones(len(codenatoms)),
+        )
+        of.write(
+            "| MD code number of atoms passed correctly | "
+            + getBadge(
+                check(
+                    basic_md_failed,
+                    np.array(codenatoms),
+                    np.array(plumednatoms),
+                    0.01 * np.ones(len(codenatoms)),
+                    0,
+                ),
+                "natoms",
+                code,
+                version,
+            )
+            + "| \n"
+        )
+        # Output results from tests on positions
+        writeReportPage(
+            "positions",
+            code,
+            version,
+            basic_md_failed,
+            ["basic"],
+            np.array(codepos),
+            plumedpos,
+            tolerance * np.ones(plumedpos.shape),
+        )
+        of.write(
+            "| MD code positions passed correctly | "
+            + getBadge(
+                check(
+                    basic_md_failed,
+                    np.array(codepos),
+                    plumedpos,
+                    tolerance * np.ones(plumedpos.shape),
+                    0,
+                ),
+                "positions",
+                code,
+                version,
+            )
+            + "| \n"
+        )
+        writeReportPage(
+            "cell",
+            code,
+            version,
+            basic_md_failed,
+            ["basic"],
+            np.array(codecell),
+            plumedcell,
+            tolerance * np.ones(plumedcell.shape),
+        )
+        of.write(
+            "| MD code cell vectors passed correctly | "
+            + getBadge(
+                check(
+                    basic_md_failed,
+                    np.array(codecell),
+                    plumedcell,
+                    tolerance * np.ones(plumedcell.shape),
+                    0,
+                ),
+                "cell",
+                code,
+                version,
+            )
+            + " | \n"
+        )
+    if info["timestep"] == "yes":
+        md_tstep, plumed_tstep = 0.1, 0.1
+        if not basic_md_failed:
+            plumedtimes = np.loadtxt("tests/" + code + "/basic_" + version + "/colvar")[
+                :, 1
+            ]
+            md_tstep, plumed_tstep = (
+                runner.getTimestep(),
+                plumedtimes[1] - plumedtimes[0],
+            )
+            for i in range(1, len(plumedtimes)):
+                if plumedtimes[i] - plumedtimes[i - 1] != plumed_tstep:
+                    ValueError("Timestep should be the same for all MD steps")
+        writeReportPage(
+            "timestep",
+            code,
+            version,
+            basic_md_failed,
+            ["basic"],
+            md_tstep,
+            plumed_tstep,
+            0.0001,
+        )
+        of.write(
+            "| MD timestep passed correctly | "
+            + getBadge(
+                check(basic_md_failed, md_tstep, plumed_tstep, 0.0001, 0),
+                "timestep",
+                code,
+                version,
+            )
+            + " | \n"
+        )
+    if info["mass"] == "yes":
+        md_masses, pl_masses = np.ones(10), np.ones(10)
+        if not basic_md_failed:
+            md_masses, pl_masses = (
+                runner.getMasses("tests/" + code + "/basic_" + version),
+                np.loadtxt("tests/" + code + "/basic_" + version + "/mq_plumed")[:, 1],
+            )
+        writeReportPage(
+            "mass",
+            code,
+            version,
+            basic_md_failed,
+            ["basic"],
+            np.array(md_masses),
+            pl_masses,
+            tolerance * np.ones(pl_masses.shape),
+        )
+        of.write(
+            "| MD code masses passed correctly | "
+            + getBadge(
+                check(
+                    basic_md_failed,
+                    np.array(md_masses),
+                    pl_masses,
+                    tolerance * np.ones(pl_masses.shape),
+                    0,
+                ),
+                "mass",
+                code,
+                version,
+            )
+            + " | \n"
+        )
+    if info["charge"] == "yes":
+        md_charges, pl_charges = np.ones(10), np.ones(10)
+        if not basic_md_failed:
+            md_charges, pl_charges = (
+                runner.getCharges("tests/" + code + "/basic_" + version),
+                np.loadtxt("tests/" + code + "/basic_" + version + "/mq_plumed")[:, 2],
+            )
+        writeReportPage(
+            "charge",
+            code,
+            version,
+            basic_md_failed,
+            ["basic"],
+            np.array(md_charges),
+            pl_charges,
+            tolerance * np.ones(pl_charges.shape),
+        )
+        of.write(
+            "| MD code charges passed correctly | "
+            + getBadge(
+                check(
+                    basic_md_failed,
+                    np.array(md_charges),
+                    pl_charges,
+                    tolerance * np.ones(pl_charges.shape),
+                    0,
+                ),
+                "charge",
+                code,
+                version,
+            )
+            + " | \n"
+        )
+    if info["forces"] == "yes":
+        # First run a calculation to find the reference distance between atom 1 and 2
+        rparams = runner.setParams()
+        rparams["nsteps"], rparams["ensemble"] = 2, "nvt"
+        rparams["plumed"] = "dd: DISTANCE ATOMS=1,2 \nPRINT ARG=dd FILE=colvar"
+        refrun, mdrun, plrun = (
+            runMDCalc("refres", code, version, runner, rparams),
+            True,
+            True,
+        )
+        if not refrun:
+            # Get the reference distance betwene the atoms
+            refdist = np.loadtxt("tests/" + code + "/refres_" + version + "/colvar")[
+                0, 1
+            ]
+            # Run the calculation with the restraint applied by the MD code
+            rparams["nsteps"], rparams["ensemble"] = 20, "nvt"
+            rparams["restraint"] = refdist
+            rparams["plumed"] = "dd: DISTANCE ATOMS=1,2 \nPRINT ARG=dd FILE=colvar"
+            mdrun = runMDCalc("forces1", code, version, runner, rparams)
+            # Run the calculation with the restraint applied by PLUMED
+            rparams["restraint"] = -10
+            rparams["plumed"] = (
+                "dd: DISTANCE ATOMS=1,2 \nRESTRAINT ARG=dd KAPPA=2000 AT="
+                + str(refdist)
+                + "\nPRINT ARG=dd FILE=colvar"
+            )
+            plrun = runMDCalc("forces2", code, version, runner, rparams)
+        # And create our reports from the two runs
+        md_failed, val1, val2 = mdrun or plrun, np.ones(1), np.ones(1)
+        if not md_failed:
+            val1, val2 = (
+                np.loadtxt("tests/" + code + "/forces1_" + version + "/colvar")[:, 1],
+                np.loadtxt("tests/" + code + "/forces2_" + version + "/colvar")[:, 1],
+            )
+        writeReportPage(
+            "forces",
+            code,
+            version,
+            md_failed,
+            ["forces1", "forces2"],
+            val1,
+            val2,
+            tolerance * np.ones(val1.shape),
+        )
+        of.write(
+            "| PLUMED forces passed correctly | "
+            + getBadge(
+                check(
+                    md_failed, val1, val2, tolerance * np.ones(val1.shape), tolerance
+                ),
+                "forces",
+                code,
+                version,
+            )
+            + " | \n"
+        )
+    if info["virial"] == "yes":
+        params = runner.setParams()
+        params["nsteps"], params["ensemble"] = 50, "npt"
+        params["plumed"] = "vv: VOLUME \n PRINT ARG=vv FILE=volume"
+        run1 = runMDCalc("virial1", code, version, runner, params)
+        params["pressure"] = 1001 * params["pressure"]
+        run3 = runMDCalc("virial3", code, version, runner, params)
+        params["plumed"] = (
+            "vv: VOLUME \n RESTRAINT AT=0.0 ARG=vv SLOPE=-60.221429 \nPRINT ARG=vv FILE=volume"
+        )
+        run2 = runMDCalc("virial2", code, version, runner, params)
+        md_failed, val1, val2, val3 = (
+            run1 or run2 or run3,
+            np.ones(1),
+            np.ones(1),
+            np.ones(1),
+        )
+        if not md_failed:
+            val1, val2, val3 = (
+                np.loadtxt("tests/" + code + "/virial1_" + version + "/volume")[:, 1],
+                np.loadtxt("tests/" + code + "/virial2_" + version + "/volume")[:, 1],
+                np.loadtxt("tests/" + code + "/virial3_" + version + "/volume")[:, 1],
+            )
+        writeReportPage(
+            "virial",
+            code,
+            version,
+            md_failed,
+            ["virial1", "virial2", "virial3"],
+            val1,
+            val2,
+            np.abs(val3 - val1),
+        )
+        of.write(
+            "| PLUMED virial passed correctly | "
+            + getBadge(
+                check(md_failed, val1, val2, np.abs(val3 - val1), tolerance),
+                "virial",
+                code,
+                version,
+            )
+            + " | \n"
+        )
+    if info["energy"] == "yes":
+        params["nsteps"], params["plumed"] = 150, "e: ENERGY \nPRINT ARG=e FILE=energy"
+        md_failed, md_energy, pl_energy = (
+            runMDCalc("energy", code, version, runner, params),
+            np.ones(1),
+            np.ones(1),
+        )
+        if not md_failed and os.path.exists(
+            "tests/" + code + "/energy_" + version + "/energy"
+        ):
+            md_energy, pl_energy = (
+                runner.getEnergy("tests/" + code + "/energy_" + version),
+                np.loadtxt("tests/" + code + "/energy_" + version + "/energy")[:, 1],
+            )
+        else:
+            md_failed = True
+        writeReportPage(
+            "energy",
+            code,
+            version,
+            md_failed,
+            ["energy"],
+            md_energy,
+            pl_energy,
+            tolerance * np.ones(len(md_energy)),
+        )
+        of.write(
+            "| MD code potential energy passed correctly | "
+            + getBadge(
+                check(
+                    md_failed,
+                    md_energy,
+                    pl_energy,
+                    tolerance * np.ones(len(md_energy)),
+                    tolerance,
+                ),
+                "energy",
+                code,
+                version,
+            )
+            + " | \n"
+        )
+        sqrtalpha = 1.1
+        alpha = sqrtalpha * sqrtalpha
+        if info["engforces"] == "yes":
+            params = runner.setParams()
+            params["nsteps"], params["ensemble"] = 50, "nvt"
+            params["plumed"] = "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy"
+            run1 = runMDCalc("engforce1", code, version, runner, params)
+            params["temperature"] = params["temperature"] * alpha
+            params["relaxtime"] = params["relaxtime"] / sqrtalpha
+            params["tstep"] = params["tstep"] / sqrtalpha
+            run3 = runMDCalc("engforce3", code, version, runner, params)
+            params["plumed"] = (
+                "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy \n RESTRAINT AT=0.0 ARG=e SLOPE="
+                + str(alpha - 1)
+            )
+            run2 = runMDCalc("engforce2", code, version, runner, params)
+            md_failed, val1, val2, val3 = (
+                run1 or run2 or run3,
+                np.ones(1),
+                np.ones(1),
+                np.ones(1),
+            )
+            if not md_failed:
+                val1, val2, val3 = (
+                    np.loadtxt("tests/" + code + "/engforce1_" + version + "/energy")[
+                        :, 1:
+                    ],
+                    np.loadtxt("tests/" + code + "/engforce2_" + version + "/energy")[
+                        :, 1:
+                    ],
+                    np.loadtxt("tests/" + code + "/engforce3_" + version + "/energy")[
+                        :, 1:
+                    ],
+                )
+            writeReportPage(
+                "engforce",
+                code,
+                version,
+                md_failed,
+                ["engforce1", "engforce2", "engforce3"],
+                val1,
+                val2,
+                np.abs(val1 - val3),
+            )
+            of.write(
+                "| PLUMED forces on potential energy passed correctly | "
+                + getBadge(
+                    check(md_failed, val1, val2, np.abs(val1 - val3), tolerance),
+                    "engforce",
+                    code,
+                    version,
+                )
+                + " | \n"
+            )
+        if info["engforces"] and info["virial"] == "yes":
+            params = runner.setParams()
+            params["nsteps"], params["ensemble"] = 150, "npt"
+            params["plumed"] = "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy"
+            run1 = runMDCalc("engvir1", code, version, runner, params)
+            params["temperature"] = params["temperature"] * alpha
+            params["relaxtime"], params["prelaxtime"] = (
+                params["relaxtime"] / sqrtalpha,
+                params["prelaxtime"] / sqrtalpha,
+            )
+            params["tstep"] = params["tstep"] / sqrtalpha
+            run3 = runMDCalc("engvir3", code, version, runner, params)
+            params["plumed"] = (
+                "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy \n RESTRAINT AT=0.0 ARG=e SLOPE="
+                + str(alpha - 1)
+            )
+            run2 = runMDCalc("engvir2", code, version, runner, params)
+            md_failed, val1, val2, val3 = (
+                run1 or run2 or run3,
+                np.ones(1),
+                np.ones(1),
+                np.ones(1),
+            )
+            if not md_failed:
+                val1, val2, val3 = (
+                    np.loadtxt("tests/" + code + "/engvir1_" + version + "/energy")[
+                        :, 1:
+                    ],
+                    np.loadtxt("tests/" + code + "/engvir2_" + version + "/energy")[
+                        :, 1:
+                    ],
+                    np.loadtxt("tests/" + code + "/engvir3_" + version + "/energy")[
+                        :, 1:
+                    ],
+                )
+            writeReportPage(
+                "engvir",
+                code,
+                version,
+                md_failed,
+                ["engvir1", "engvir2", "engvir3"],
+                val1,
+                val2,
+                np.abs(val1 - val3),
+            )
+            of.write(
+                "| PLUMED contribution to virial due to force on potential energy passed correctly | "
+                + getBadge(
+                    check(md_failed, val1, val2, np.abs(val1 - val3), tolerance),
+                    "engvir",
+                    code,
+                    version,
+                )
+                + " | \n"
+            )
+    of.close()
+    # Read output file to get status
+    ifn, of = open("tests/" + code + "/" + fname, "r"), open(
+        "tests/" + code + "/info.yml", "a"
+    )
+    inp = ifn.read()
+    ifn.close()
+    if "failed-red.svg" in inp:
+        of.write("test_plumed" + version + ": broken \n")
+    elif "%25-green.svg" in inp and ("%25-red.svg" in inp or "%25-yellow.svg" in inp):
+        of.write("test_plumed" + version + ": partial\n")
+    elif "%25-yellow.svg" in inp:
+        of.write("test_plumed" + version + ": partial\n")
+    elif "%25-green.svg" in inp:
+        of.write("test_plumed" + version + ": working \n")
+    elif "%25-red.svg" in inp:
+        of.write("test_plumed" + version + ": broken \n")
+    else:
+        raise Exception(
+            "Found no test badges in output for tests on " + code + " with " + version
+        )
+    of.close()
 
-def check( md_failed, val1, val2, val3, tolerance ) :
-   if md_failed : return -1
-   if hasattr(val2, "__len__") and len(val1)!=len(val2) : return -1
-   if hasattr(val2, "__len__") and len(val3)!=len(val2) : return -1
-   percent_diff = 100*np.divide( np.abs( val1 - val2 ), val3, out=np.zeros_like(val3), where=val3>tolerance ) 
-   return int(np.round( np.average( percent_diff ) )) 
 
-if __name__ == "__main__" :
-   code, version, argv = "", "", sys.argv[1:]
-   try:
-     opts, args = getopt.getopt(argv,"hc:v:",["code="])
-   except:
-       print('runtests.py -c <code> -v <version>')
+def getBadge(sucess, filen, code, version):
+    badge = (
+        "[![tested on " + version + "](https://img.shields.io/badge/" + version + "-"
+    )
+    if sucess < 0:
+        badge = badge + "failed-red.svg"
+    elif sucess < 5:
+        badge = badge + "fail " + str(sucess) + "%25-green.svg"
+    elif sucess < 20:
+        badge = badge + "fail " + str(sucess) + "%25-yellow.svg"
+    else:
+        badge = badge + "fail " + str(sucess) + "%25-yellow.svg"
+    return badge + ")](" + filen + "_" + version + ".html)"
 
-   for opt, arg in opts:
-       if opt in ['-h'] :
-          print('runtests.py -c <code>')
-          sys.exit()
-       elif opt in ["-c", "--code"]:
-          code = arg
-       elif opt in ["-v", "--version"]:
-          version = arg
 
-   # Build all the pages that describe the tests for this code
-   buildTestPages( "tests/" + code )
-   # Copy the engforce file 
-   shutil.copy("pages/engforce.md","pages/engvir.md")
-   # Build the default test pages
-   buildTestPages( "pages" )
-   # Create an __init__.py module for the desired code
-   ipf = open("tests/" + code + "/__init__.py", "w+")
-   ipf.write("from .mdcode import mdcode\n")
-   ipf.close()
-   # Now import the module
-   d = importlib.import_module( "tests." + code, "mdcode" )
-   # And create the class that interfaces with the MD code output
-   runner = d.mdcode()
-   # Now run the tests 
-   runTests( code, version, runner )
+def writeReportPage(filen, code, version, md_fail, zipfiles, ref, data, denom):
+    # Read in the file
+    f = open("pages/" + filen + ".md", "r")
+    inp = f.read()
+    f.close()
+    # Now output the file
+    of = open("tests/" + code + "/" + filen + "_" + version + ".md", "w+")
+    for line in inp.splitlines():
+        if "Trajectory" in line and "#" in line:
+            if len(zipfiles) != 1:
+                raise ValueError("wrong number of trajectories")
+            of.write(line + "\n")
+            of.write(
+                "Input and output files for the test calculation are available in this [zip archive]("
+                + zipfiles[0]
+                + "_"
+                + version
+                + ".zip) \n\n"
+            )
+        elif "Trajectories" in line and "#" in line:
+            if len(zipfiles) == 2:
+                of.write(line + "\n")
+                of.write(
+                    "1. Input and output files for the calculation where the restraint is applied by the MD code available in this [zip archive]("
+                    + zipfiles[0]
+                    + "_"
+                    + version
+                    + ".zip) \n"
+                )
+                of.write(
+                    "2. Input and output files for the calculation where the restraint is applied by PLUMED are available in this [zip archive]("
+                    + zipfiles[1]
+                    + "_"
+                    + version
+                    + ".zip) \n\n"
+                )
+            elif len(zipfiles) == 3:
+                of.write(line + "\n")
+                of.write(
+                    "1. Input and output files for the unpeturbed calculation are available in this [zip archive]("
+                    + zipfiles[0]
+                    + "_"
+                    + version
+                    + ".zip) \n"
+                )
+                of.write(
+                    "2. Input and output files for the peturbed calculation are available in this [zip archive]("
+                    + zipfiles[2]
+                    + "_"
+                    + version
+                    + ".zip) \n\n"
+                )
+                of.write(
+                    "2. Input and output files for the peturbed calculation in which a PLUMED restraint is used to undo the effect of the changed MD parameters are available in this [zip archive]("
+                    + zipfiles[1]
+                    + "_"
+                    + version
+                    + ".zip) \n\n"
+                )
+            else:
+                raise ValueError("wrong number of trajectories")
+        elif "Results" in line and "#" in line and md_fail:
+            of.write(line + "\n")
+            of.write(
+                "Calculations were not sucessful and no data was generated for comparison\n"
+            )
+        else:
+            of.write(line + "\n")
+    if not md_fail and hasattr(data, "__len__"):
+        if len(zipfiles) == 1:
+            of.write(
+                "\n| MD code output | PLUMED output | Tolerance | % Difference | \n"
+            )
+        else:
+            of.write(
+                "\n| Original result | Result with PLUMED | Effect of peturbation | % Difference | \n"
+            )
+        of.write("|:-------------|:--------------|:--------------|:--------------| \n")
+        nlines = min(20, len(ref))
+        percent_diff = 100 * np.divide(
+            np.abs(ref - data), denom, out=np.zeros_like(denom), where=denom != 0
+        )
+        for i in range(nlines):
+            if hasattr(ref[i], "__len__"):
+                ref_strings = ["%.4f" % x for x in ref[i]]
+                data_strings = ["%.4f" % x for x in data[i]]
+                denom_strings = ["%.4f" % x for x in denom[i]]
+                pp_strings = ["%.4f" % x for x in percent_diff[i]]
+                of.write(
+                    "|"
+                    + " ".join(ref_strings)
+                    + " | "
+                    + " ".join(data_strings)
+                    + " | "
+                    + " ".join(denom_strings)
+                    + " | "
+                    + " ".join(pp_strings)
+                    + "| \n"
+                )
+            else:
+                of.write(
+                    "|"
+                    + str(ref[i])
+                    + " | "
+                    + str(data[i])
+                    + " | "
+                    + str(denom[i])
+                    + " | "
+                    + str(percent_diff[i])
+                    + "| \n"
+                )
+    elif not md_fail:
+        if len(zipfiles) == 1:
+            of.write(
+                "\n| MD code output | PLUMED output | Tolerance | % Difference | \n"
+            )
+        else:
+            of.write(
+                "| Original result | Result with PLUMED | Effect of peturbation | % Difference | \n"
+            )
+        of.write("|:-------------|:--------------|:--------------|:--------------| \n")
+        of.write(
+            "| "
+            + str(ref)
+            + " | "
+            + str(data)
+            + " | "
+            + str(denom)
+            + " | "
+            + str(100 * np.abs(ref - data) / denom)
+            + " | \n"
+        )
+    of.close()
+
+
+def check(md_failed, val1, val2, val3, tolerance):
+    if md_failed:
+        return -1
+    if hasattr(val2, "__len__") and len(val1) != len(val2):
+        return -1
+    if hasattr(val2, "__len__") and len(val3) != len(val2):
+        return -1
+    percent_diff = 100 * np.divide(
+        np.abs(val1 - val2), val3, out=np.zeros_like(val3), where=val3 > tolerance
+    )
+    return int(np.round(np.average(percent_diff)))
+
+
+if __name__ == "__main__":
+    code, version, argv = "", "", sys.argv[1:]
+    try:
+        opts, args = getopt.getopt(argv, "hc:v:", ["code="])
+    except:
+        print("runtests.py -c <code> -v <version>")
+
+    for opt, arg in opts:
+        if opt in ["-h"]:
+            print("runtests.py -c <code>")
+            sys.exit()
+        elif opt in ["-c", "--code"]:
+            code = arg
+        elif opt in ["-v", "--version"]:
+            version = arg
+
+    # Build all the pages that describe the tests for this code
+    buildTestPages("tests/" + code)
+    # Copy the engforce file
+    shutil.copy("pages/engforce.md", "pages/engvir.md")
+    # Build the default test pages
+    buildTestPages("pages")
+    # Create an __init__.py module for the desired code
+    ipf = open("tests/" + code + "/__init__.py", "w+")
+    ipf.write("from .mdcode import mdcode\n")
+    ipf.close()
+    # Now import the module
+    d = importlib.import_module("tests." + code, "mdcode")
+    # And create the class that interfaces with the MD code output
+    runner = d.mdcode()
+    # Now run the tests
+    runTests(code, version, runner)

--- a/runtests.py
+++ b/runtests.py
@@ -393,9 +393,9 @@ PRINT ARG=c.* FILE=cell_data
             )
             plrun_fail = runMDCalc("forces2", params=rparams, **runMDCalcSettings)
             # And create our reports from the two runs
-            md_failed = mdrun_fail or plrun_fail
-            val1 = np.ones(1)
-            val2 = np.ones(1)
+        md_failed = mdrun_fail or plrun_fail
+        val1 = np.ones(1)
+        val2 = np.ones(1)
         if not md_failed:
             val1 = np.loadtxt(f"{outdir}/forces1_{version}/colvar")[:, 1]
             val2 = np.loadtxt(f"{outdir}/forces2_{version}/colvar")[:, 1]


### PR DESCRIPTION
I added a way to run the tests in local without impacting on the files tracked by git.

Functionality-wise:
 - I added a prefix to the functions that prepares the markdown files
 - I added a prefix to the working directory
 - I added a new file, `localrun.py` that has the logic to do this
   - But as now it does not accept arguments, and need to be manually reconfigured
   - To rerun things `shutil.copytree(f"{basedir}/input", f"{wdir}")` needs a clean target and fails otherwise, so you must manually remove local_test/, in some way this act as a safeguard to accidentally override previous results
   - To work needs plumed in the PATH, with no suffixes (can be changed in `localrun.py`)
   - To work needs the patched MD engine int PATH, with no suffixes (can be changed in `localrun.py`, but as now the suffix must be the plumed version returned by `plumed info --version`)

Code-wise:
 - I ran black on `runtest.py`, and black does not like long lines, and that triples the lines
 - I changed some string+variable concatenation to fstrings
 - I changed the multiple occurrences of paths like `"tests/" + code` to a shortcut variable, so all the path (>40!) can be changed at once without risking of forgetting any one of the other 39, and this was very useful with adding the prefix
   - I did the same with `"tests/" + code + "/basic_{version}/"` in the block that post-processes the "basic" run
 - in a droppable commit(fed772f4927b2570f9b22b4a2a1abba83364eaa6) I corrected some spelling error
 - I changed some declarations from one line to multiple from  
```python
plumednatoms, codenatoms, codepos, plumedpos, codecell, plumedcell = [], [], np.ones(10), np.ones(10), np.ones(10), np.ones(10)
```
to
```python
plumednatoms = []
codenatoms = []
codepos = np.ones(params["nsteps"])
plumedpos = np.ones(params["nsteps"])
codecell = np.ones(params["nsteps"])
plumedcell = np.ones(params["nsteps"])
```
  this should make those line easier to understand while editing the code and clearer in new diffs


commit 83e248f254885ddefa6f7ac2438dcb12d21eaca2 is a refactor of the way some output are treated, if you prefer I will change it to a standalone PR, to talk about it. Its rationale is to not repeat the same input for consequent functions, again to avoid copy-paste errors.