### PR TITLE
Breaking runTests in blocks

### DIFF
--- a/localrun.py
+++ b/localrun.py
@@ -6,21 +6,23 @@ from runtests import buildTestPages, runTests
 
 if __name__ == "__main__":
     # to run PATH must contain the dir to plumed and the one to the executable of your code
-    code = "quantum_espresso"
+    # code = "quantum_espresso"
+    code = "gmx24"
     prefix = "local_"
     plumedToRun = [{"plumed": "plumed", "printJson": False}]
     print("Code: " + code)
     print("Preparing pages")
     # Engforce and engvir share the same procedure
     shutil.copy("pages/engforce.md", "pages/engvir.md")
-    # buildTestPages("tests/" + code, prefix, plumedToRun)
+    buildTestPages("tests/" + code, prefix, plumedToRun)
+    # this usues > 50% of the time
     buildTestPages("pages", prefix, plumedToRun)
     # Create an __init__.py module for the desired code
     with open("tests/" + code + "/__init__.py", "w") as ipf:
         ipf.write("from .mdcode import mdcode\n")
-    d = importlib.import_module("tests." + code, "mdcode")
+    myMDcode = importlib.import_module("tests." + code, "mdcode")
     # And create the class that interfaces with the MD code output
-    runner = d.mdcode()
+    runner = myMDcode.mdcode()
     # Now run the tests
     print("Running the tests on stable")
     # execNameChanged=False because in my case I have compiled qe without changing its suffix
@@ -29,5 +31,5 @@ if __name__ == "__main__":
         "stable",
         runner,
         prefix=prefix,
-        settigsFor_runMDCalc=dict(execNameChanged=False, makeArchive=False),
+        settingsFor_runMDCalc=dict(execNameChanged=False, makeArchive=False),
     )

--- a/runhelper.py
+++ b/runhelper.py
@@ -1,4 +1,4 @@
-from typing import TextIO
+from typing import TextIO, Literal
 import numpy as np
 
 
@@ -116,7 +116,13 @@ def writeReportPage(
             )
 
 
-def check(md_failed: "int|bool", val1, val2, val3, tolerance: float = 0.0) -> int:
+def check(
+    md_failed: "int|bool",
+    val1: "float|np.ndarray",
+    val2: "float|np.ndarray",
+    val3: "float|np.ndarray",
+    tolerance: float = 0.0,
+) -> int:
     # this may be part of writeReportForSimulations
     if md_failed:
         return -1
@@ -133,13 +139,20 @@ def check(md_failed: "int|bool", val1, val2, val3, tolerance: float = 0.0) -> in
 class writeReportForSimulations:
     """helper class to write the report tof the simulations"""
 
+    testout: TextIO
+    code: str
+    version: Literal["master", "stable"]
+    md_failed: "bool | int"
+    simulations: list[str]
+    prefix: str = ""
+
     def __init__(
         self,
         testout: TextIO,
         code: str,
         version: str,
-        md_failed,
-        simulations,
+        md_failed: "bool | int",
+        simulations: list[str],
         *,
         prefix="",
     ) -> None:
@@ -155,9 +168,9 @@ class writeReportForSimulations:
         self,
         kind: str,
         docstring: str,
-        val1,
-        val2,
-        val3,
+        val1: "float|np.ndarray",
+        val2: "float|np.ndarray",
+        val3: "float|np.ndarray",
         *,
         tolerance: float = 0.0,
     ):

--- a/runhelper.py
+++ b/runhelper.py
@@ -14,7 +14,7 @@ def getBadge(sucess, filen, code, version: str):
             color = "yellow"
         else:
             # shoudn't this be red?
-            color = "yellow"
+            color = "red"
         badge += f"fail%20{sucess}%25-{color}.svg"
     return badge + f")]({filen}_{version}.html)"
 
@@ -121,7 +121,7 @@ def check(
     val1: "float|np.ndarray",
     val2: "float|np.ndarray",
     val3: "float|np.ndarray",
-    tolerance: float = 0.0,
+    denominatorTolerance: float = 0.0,
 ) -> int:
     # this may be part of writeReportForSimulations
     if md_failed:
@@ -131,7 +131,10 @@ def check(
     if hasattr(val2, "__len__") and len(val3) != len(val2):
         return -1
     percent_diff = 100 * np.divide(
-        np.abs(val1 - val2), val3, out=np.zeros_like(val3), where=val3 >= tolerance
+        np.abs(val1 - val2),
+        val3,
+        out=np.zeros_like(val3),
+        where=val3 > denominatorTolerance,
     )
     return int(np.round(np.average(percent_diff)))
 
@@ -172,7 +175,7 @@ class writeReportForSimulations:
         val2: "float|np.ndarray",
         val3: "float|np.ndarray",
         *,
-        tolerance: float = 0.0,
+        denominatorTolerance: float = 0.0,
     ):
         writeReportPage(
             kind,
@@ -188,7 +191,13 @@ class writeReportForSimulations:
         self.testout.write(
             f"| {docstring} | "
             + getBadge(
-                check(self.md_failed, val1, val2, val3, tolerance=tolerance),
+                check(
+                    self.md_failed,
+                    val1,
+                    val2,
+                    val3,
+                    denominatorTolerance=denominatorTolerance,
+                ),
                 kind,
                 self.code,
                 self.version,

--- a/runtests.py
+++ b/runtests.py
@@ -366,7 +366,6 @@ def runForcesTest(
         val1,
         val2,
         tolerance * np.ones(val1.shape),
-        tolerance=tolerance,
     )
 
 
@@ -409,7 +408,7 @@ def runVirialTest(
         val1,
         val2,
         np.abs(val3 - val1),
-        tolerance=tolerance,
+        denominatorTolerance=tolerance,
     )
 
 
@@ -469,7 +468,7 @@ def energyTest(
         val1,
         val2,
         np.abs(val1 - val3),
-        tolerance=tolerance,
+        denominatorTolerance=tolerance,
     )
 
 
@@ -479,7 +478,7 @@ def runEnergyTests(
     code = runMDCalcSettings["code"]
     prefix = runMDCalcSettings["prefix"]
     version = runMDCalcSettings["version"]
-    params = runMDCalcSettings["runner"].setParams()   
+    params = runMDCalcSettings["runner"].setParams()
     params["nsteps"] = 150
     params["ensemble"] = "npt"
     params["plumed"] = "e: ENERGY \nPRINT ARG=e FILE=energy"
@@ -505,13 +504,7 @@ def runEnergyTests(
         "MD code potential energy passed correctly",
         md_energy,
         pl_energy,
-        ########################################################################
-        # since in check we have where=val3 > tolerance this make the test skip
-        # the badge and return a failure rate of 0, always
-        # tolerance * np.ones(len(md_energy)),
-        # could this be a valid alternative?
-        (np.abs(md_energy) + np.abs(pl_energy)) / 2.0,
-        tolerance=tolerance,
+        tolerance * np.ones(len(md_energy)),
     )
     # TODO:https://docs.python.org/3/library/string.html#template-strings
     # the .md files can be templated with this string built-in feature,

--- a/runtests.py
+++ b/runtests.py
@@ -493,25 +493,18 @@ def runEnergyTests(
         params = runner.setParams()
         params["nsteps"] = 50
         params["ensemble"] = "nvt"
-        params[
-            "plumed"
-        ] = """e: ENERGY
-v: VOLUME
-PRINT ARG=e,v FILE=energy
-"""
+        params["plumed"] = "e: ENERGY\n" "v: VOLUME\n" "PRINT ARG=e,v FILE=energy\n"
         run1_fail = runMDCalc("engforce1", params=params, **runMDCalcSettings)
         params["temperature"] = params["temperature"] * alpha
         params["relaxtime"] = params["relaxtime"] / sqrtalpha
         params["tstep"] = params["tstep"] / sqrtalpha
         run3_fail = runMDCalc("engforce3", params=params, **runMDCalcSettings)
-        params[
-            "plumed"
-        ] = f"""e: ENERGY
-v: VOLUME
-PRINT ARG=e,v FILE=energy
-RESTRAINT AT=0.0 ARG=e SLOPE={alpha - 1}
-"""
-
+        params["plumed"] = (
+            "e: ENERGY\n"
+            "v: VOLUME\n"
+            "PRINT ARG=e,v FILE=energy\n"
+            f"RESTRAINT AT=0.0 ARG=e SLOPE={alpha - 1}\n"
+        )
         run2_fail = runMDCalc("engforce2", params=params, **runMDCalcSettings)
         md_failed = run1_fail or run2_fail or run3_fail
         val1 = np.ones(1)
@@ -539,12 +532,13 @@ RESTRAINT AT=0.0 ARG=e SLOPE={alpha - 1}
             np.abs(val1 - val3),
             tolerance=tolerance,
         )
-
+    sqrtalpha = 1.1
+    alpha = sqrtalpha * sqrtalpha
     if info["engforces"] and info["virial"] == "yes":
         params = runner.setParams()
         params["nsteps"] = 150
         params["ensemble"] = "npt"
-        params["plumed"] = "e: ENERGY\n v: VOLUME \n PRINT ARG=e,v FILE=energy"
+        params["plumed"] = "e: ENERGY\n" "v: VOLUME\n" "PRINT ARG=e,v FILE=energy\n"
         run1_fail = runMDCalc("engvir1", params=params, **runMDCalcSettings)
         params["temperature"] = params["temperature"] * alpha
         params["relaxtime"] = params["relaxtime"] / sqrtalpha
@@ -555,7 +549,7 @@ RESTRAINT AT=0.0 ARG=e SLOPE={alpha - 1}
             "e: ENERGY\n"
             "v: VOLUME\n"
             "PRINT ARG=e,v FILE=energy\n"
-            f"RESTRAINT AT=0.0 ARG=e SLOPE={alpha - 1}"
+            f"RESTRAINT AT=0.0 ARG=e SLOPE={alpha - 1}\n"
         )
         run2_fail = runMDCalc("engvir2", params=params, **runMDCalcSettings)
         md_failed = run1_fail or run2_fail or run3_fail

--- a/runtests.py
+++ b/runtests.py
@@ -517,7 +517,12 @@ def runEnergyTests(
         "MD code potential energy passed correctly",
         md_energy,
         pl_energy,
-        tolerance * np.ones(len(md_energy)),
+        ########################################################################
+        # since in check we have where=val3 > tolerance this make the test skip
+        # the badge and return a failure rate of 0, always
+        # tolerance * np.ones(len(md_energy)),
+        # could this be a valid alternative?
+        (np.abs(md_energy) + np.abs(pl_energy)) / 2.0,
         tolerance=tolerance,
     )
     # TODO:https://docs.python.org/3/library/string.html#template-strings

--- a/runtests.py
+++ b/runtests.py
@@ -393,9 +393,9 @@ PRINT ARG=c.* FILE=cell_data
             )
             plrun_fail = runMDCalc("forces2", params=rparams, **runMDCalcSettings)
             # And create our reports from the two runs
-            md_failed = mdrun_fail or plrun_fail
-            val1 = np.ones(1)
-            val2 = np.ones(1)
+        md_failed = mdrun_fail or plrun_fail
+        val1 = np.ones(1)
+        val2 = np.ones(1)
         if not md_failed:
             val1 = np.loadtxt(f"{outdir}/forces1_{version}/colvar")[:, 1]
             val2 = np.loadtxt(f"{outdir}/forces2_{version}/colvar")[:, 1]


### PR DESCRIPTION
This is a followup to #7:

Main changes:
 - I broke up the runTests function in smaller blocks:
   - `runBasicTests` that does the minimum work (positions=yes, timestep=yes, masses=yes and charges=yes)
   - `runForcesTest` (forces=yes)
   - `runVirialTest` (virial=yes)
   - `runEnergyTests` (energy=yes and "energy=yes + virial=yes")
 - removed some code repetition in runEnergyTests
 - compacted how settings are passed between functions via `**` and `dict`s

I think that these changes should make easier to keep the code working

minor changes:
 - I added some types to help vscode in helping me working

The PR is in draft because I have found some bugs(or unwanted behavior?) tha I think can be addressed here:

- (runtest.py:484) In breaking the main function in blocks I discovered that in the monolithic function the `runEnergyTests` block inherits the parameter variable modified by the previous tests in the, so I do not know what should be the wanted settings
- (runtest.py:368,523) we spoke about this this morning: since in check we have `np.divide(np.abs(val1 - val2), val3, out=np.zeros_like(val3), where=val3 > tolerance)` calling check with `val3=tolerance * np.ones(len(md_energy))` cause the division to not be calculated for all of the elements, and so the check passes with 0 as error, making the test pass for all the steps. (I noted it here because the plumed module I am working on for gromacs 24 does not pass the energy in code, but passed the "energy=yes" test with 0% error anyway)


---

A thing that I should have asked in #7, in `getBadge`:
```python
def getBadge(sucess, filen, code, version: str):
    badge = f"[![tested on {version}](https://img.shields.io/badge/{version}-"
    if sucess < 0:
        badge += "failed-red.svg"
    else:
        color = "red"
        if sucess < 5:
            color = "green"
        elif sucess < 20:
            color = "yellow"
        else:
            color = "yellow"
        badge += f"fail%20{sucess}%25-{color}.svg"
```
should the badge for >20% of error be red? because now get things like ![](https://img.shields.io/badge/master-fail%20160%25-yellow.svg) and the `elif "%25-red.svg" in inp:` in runtest.py:641 will never be triggered