### PR TITLE
Changed in how the browse page is written down in markdown

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,3 +246,12 @@ jobs:
           enable_jekyll: true
           user_name: 'PlumedBot'
           user_email: 'giovanni.bussi+plumedbot@gmail.com'
+    - name: Upload a debug artifact
+      if: github.ref != 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      # for this we do not care about losing permissions
+      with:
+          name: debug-deploy
+          path: ./tmp/deploy
+          compression-level: 9
+          retention-days: 1

--- a/build.py
+++ b/build.py
@@ -4,26 +4,56 @@ import os
 from datetime import date
 
 
+def isTest(path) -> bool:
+    """
+    Check if a directory can be considered a test directory.
+    It is a test directory if it contains the three files:
+    - info.yml
+    - install.sh
+    - mdcode.py
+    """
+    if os.path.isdir(path):
+        for file in ["info.yml", "install.sh", "mdcode.py"]:
+            if not os.path.isfile(path + "/" + file):
+                return False
+        return True
+    return False
+
+
 def checkWorkflow():
     print("Checking Workflow")
-    f = open(".github/workflows/main.yml", "r")
-    inp = f.read()
-    f.close()
+    # this works with the replica list written like this
+    ###
+    # replica:
+    #  - "simplemd"
+    #  - "lammps"
+    #  - "quantum_espresso"
+    #  - "i-pi"
+    #  - "gromacs"
+    #  - "gromacs-vanilla"
+    ### or like this:
+    # replica: ["simplemd", "lammps", "quantum_espresso", "i-pi", "gromacs", "gromacs-vanilla"]
+    with open(".github/workflows/main.yml", "r") as f:
+        workflow = yaml.load(f, Loader=yaml.BaseLoader)
+        replicalist = workflow["jobs"]["build"]["strategy"]["matrix"]["replica"]
 
-    for line in inp.splitlines():
-        if "replica:" in line:
-            adirs = (
-                line.replace("replica:", "")
-                .replace("[", "")
-                .replace("]", "")
-                .replace(",", "")
-                .split()
-            )
-            rdirs = os.listdir("tests")
-            if rdirs != adirs:
-                ValueError(
-                    "Tests have not been updated. Run the command create_workflow.py in create_workflow directory and commit the changes to .github/actions/main.yml"
-                )
+        testdirs = [d for d in os.listdir("tests") if isTest("tests/" + d)]
+
+        replicalist = sorted(replicalist)
+        testdirs = sorted(testdirs)
+        if testdirs != replicalist:
+            error = "Tests have not been updated.\n"
+            if len(testdirs) > len(replicalist):
+                error += "The following tests are missing from the workflow file:\n"
+                for t in testdirs:
+                    if t not in replicalist:
+                        error += " - " + t + "\n"
+            else:
+                error += "The following test in the workflow do not have their own directory:\n"
+                for t in replicalist:
+                    if t not in testdirs:
+                        error += " - " + t + "\n"
+            raise ValueError(error)
 
 
 def buildBrowsePage(stable_version, tested):
@@ -37,12 +67,12 @@ def buildBrowsePage(stable_version, tested):
    |:-----------------|:------------------|:--------:|:------------:|"""
 
     for code in os.listdir("tests"):
-        if os.path.isfile("tests/" + code):
+        if  not isTest("tests/" + code):
             continue
         compile_badge, test_badge = "", ""
 
-        with open("tmp/extract/tests/" + code + "/info.yml", "r") as stram:
-            info = yaml.load(stram, Loader=yaml.BaseLoader)
+        with open("tmp/extract/tests/" + code + "/info.yml", "r") as stream:
+            info = yaml.load(stream, Loader=yaml.BaseLoader)
 
         for i in range(len(tested)):
             compile_badge += (
@@ -64,6 +94,7 @@ def buildBrowsePage(stable_version, tested):
                 f" [![tested on {tested[i]}](https://img.shields.io/badge/{tested[i]}-"
             )
             test_status = info["test_plumed" + tested[i]]
+
             if test_status == "working":
                 test_badge += "passing-green.svg"
             elif test_status == "partial":
@@ -72,9 +103,9 @@ def buildBrowsePage(stable_version, tested):
                 test_badge += "broken-red.svg"
             elif test_status == "failing":
                 test_badge += "failed-red.svg"
+
             if tested[i] != stable_version:
                 test_badge += f")](tests/{code}/testout_{tested[i]}.html)"
-
             else:
                 test_badge = test_badge + ")](tests/" + code + "/testout.html)"
         browse += f"| [{code}]({info['link']}) | {info['description']} | {compile_badge} | {test_badge} | \n"
@@ -105,10 +136,14 @@ When the tests above are run PLUMED is built using the install plumed action.
 
 
 if __name__ == "__main__":
-    # Check that the workflow matches with the directories
-    checkWorkflow()
-    # Build the page with all the MD codes
-    vf = open("tmp/extract/stable_version.md", "r")
-    stable_version = vf.read()
-    vf.close()
-    buildBrowsePage("v" + stable_version, ("v" + stable_version, "master"))
+    try:
+        # Check that the workflow matches with the directories
+        checkWorkflow()
+        # Build the page with all the MD codes
+        with open("tmp/extract/stable_version.md", "r") as vf:
+            stable_version = vf.read()
+
+        buildBrowsePage("v" + stable_version, ("v" + stable_version, "master"))
+    except Exception as e:
+        print(e)
+        exit(1)

--- a/build.py
+++ b/build.py
@@ -95,7 +95,7 @@ def buildBrowsePage(stable_version, tested):
             test_badge += (
                 f" [![tested on {tested[i]}](https://img.shields.io/badge/{tested[i]}-"
             )
-            test_status = info["test_plumed" + tested[i]]
+            test_status = info["test_plumed_" + version]
 
             if test_status == "working":
                 test_badge += "passing-green.svg"

--- a/build.py
+++ b/build.py
@@ -63,13 +63,15 @@ def buildBrowsePage(stable_version, tested):
    
    The codes listed below below were tested on __{date.today().strftime("%B %d, %Y")}__. """
     browse += """PLUMED-TESTCENTER tested whether the current and development versions of the code can be used to complete the tests for each of these codes.
-   | Name of Program  | Short description | Compiles | Passes tests |
-   |:-----------------|:------------------|:--------:|:------------:|"""
+| Name of Program  | Short description | Compiles | Passes tests |
+|:-----------------|:------------------|:--------:|:------------:|
+"""
 
     for code in os.listdir("tests"):
         if  not isTest("tests/" + code):
             continue
-        compile_badge, test_badge = "", ""
+        compile_badge=""
+        test_badge = ""
 
         with open("tmp/extract/tests/" + code + "/info.yml", "r") as stream:
             info = yaml.load(stream, Loader=yaml.BaseLoader)
@@ -85,8 +87,8 @@ def buildBrowsePage(stable_version, tested):
             elif compile_status == "broken":
                 compile_badge += "failed-red.svg"
             else:
-                ValueError(
-                    f"found invalid compilation status for {code} should be 'working' or 'broken', is '{compile_status}'"
+                raise ValueError(
+                    f"found invalid compilation status for {code}['test_plumed{tested[i]}'] should be 'working' or 'broken', is '{compile_status}'"
                 )
             compile_badge += ")](tests/" + code + "/install.html)"
 
@@ -103,6 +105,10 @@ def buildBrowsePage(stable_version, tested):
                 test_badge += "broken-red.svg"
             elif test_status == "failing":
                 test_badge += "failed-red.svg"
+            else:
+                raise ValueError(
+                    f"found invalid test status for {code}['test_plumed{tested[i]}'] should be 'working', 'partial', 'failing' or 'broken', is '{test_status}'"
+                )
 
             if tested[i] != stable_version:
                 test_badge += f")](tests/{code}/testout_{tested[i]}.html)"
@@ -123,7 +129,7 @@ When the tests above are run PLUMED is built using the install plumed action.
          version: "${{ steps.get-key.outputs.branch }}"
          extra_options: --enable-boost_serialization --enable-fftw --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH --disable-basic-warnings
 ```
-   """
+"""
     # no more necessary
     # browse+=" \n"
     # browse+="```bash\n"

--- a/build.py
+++ b/build.py
@@ -1,69 +1,114 @@
+# formatted with ruff 0.6.4
 import yaml
 import os
 from datetime import date
 
-def checkWorkflow() : 
-   print("Checking Workflow")
-   f = open(".github/workflows/main.yml","r")
-   inp = f.read()
-   f.close()
 
-   for line in inp.splitlines() :
-       if "replica:" in line :
-          adirs = line.replace("replica:","").replace("[","").replace("]","").replace(",","").split()
-          rdirs = os.listdir("tests")
-          if rdirs != adirs :
-             ValueError("Tests have not been updated. Run the command create_workflow.py in create_workflow directory and commit the changes to .github/actions/main.yml")
+def checkWorkflow():
+    print("Checking Workflow")
+    f = open(".github/workflows/main.yml", "r")
+    inp = f.read()
+    f.close()
 
-def buildBrowsePage( stable_version, tested ) :
-   print("Building browse page")
-   f = open("browse.md","w+")
-   f.write("Browse the tests\n")
-   f.write("-----------------\n")
-   f.write("The codes listed below below were tested on __" + date.today().strftime("%B %d, %Y") + "__. ")
-   f.write("PLUMED-TESTCENTER tested whether the current and development versions of the code can be used to complete the tests for each of these codes.\n \n")
-   f.write("| Name of Program  | Short description | Compiles | Passes tests | \n")
-   f.write("|:-----------------|:------------------|:--------:|:------------:| \n")
-   for code in os.listdir("tests") :
-       if os.path.isfile("tests/" + code) : continue
-       compile_badge, test_badge = "", ""
-       stram=open("tmp/extract/tests/" + code + "/info.yml", "r")
-       info=yaml.load(stram,Loader=yaml.BaseLoader)
-       stram.close()
-       for i in range(len(tested)):
-           compile_badge = compile_badge + ' [![tested on ' + tested[i] + '](https://img.shields.io/badge/' + tested[i] + '-'
-           compile_status=info["install_plumed_" + tested[i] ]
-           if compile_status=="working" : compile_badge = compile_badge + 'passing-green.svg'
-           elif compile_status=="broken" : compile_badge = compile_badge + 'failed-red.svg'
-           else : ValueError("found invalid compilation status for " + code + " should be working or broken")
-           compile_badge = compile_badge + ')](tests/' + code + '/install.html)'
-           test_badge = test_badge + ' [![tested on ' + tested[i] + '](https://img.shields.io/badge/' + tested[i] + '-'
-           test_status = info["test_plumed" + tested[i]]
-           if test_status=="working" : test_badge = test_badge + 'passing-green.svg'
-           elif test_status=="partial" : test_badge = test_badge + 'partial-yellow.svg'
-           elif test_status=="broken" : test_badge = test_badge + 'broken-red.svg'
-           elif test_status=="failing"  : test_badge = test_badge + 'failed-red.svg'
-           if tested[i]!=stable_version : test_badge = test_badge + ')](tests/' + code + '/testout_' + tested[i] + '.html)' 
-           else : test_badge = test_badge + ')](tests/' + code + '/testout.html)'
-       f.write("| [" + code + "](" + info["link"] +") | " + info["description"] + " | " + compile_badge + " | " + test_badge + " | \n")  
-   f.write(" \n")
-   f.write("**Building PLUMED**\n")
-   f.write(" \n")
-   f.write("When the tests above are run PLUMED is built using the following bash script.\n")
-   f.write(" \n")
-   f.write("```bash\n")
-   sf = open(".ci/install.plumed","r")
-   inp = sf.read()
-   for line in inp.splitlines() : f.write( line + "\n")
-   f.write("```\n")
-   f.close()
+    for line in inp.splitlines():
+        if "replica:" in line:
+            adirs = (
+                line.replace("replica:", "")
+                .replace("[", "")
+                .replace("]", "")
+                .replace(",", "")
+                .split()
+            )
+            rdirs = os.listdir("tests")
+            if rdirs != adirs:
+                ValueError(
+                    "Tests have not been updated. Run the command create_workflow.py in create_workflow directory and commit the changes to .github/actions/main.yml"
+                )
+
+
+def buildBrowsePage(stable_version, tested):
+    print("Building browse page")
+
+    browse = f"""## Browse the tests
+   
+   The codes listed below below were tested on __{date.today().strftime("%B %d, %Y")}__. """
+    browse += """PLUMED-TESTCENTER tested whether the current and development versions of the code can be used to complete the tests for each of these codes.
+   | Name of Program  | Short description | Compiles | Passes tests |
+   |:-----------------|:------------------|:--------:|:------------:|"""
+
+    for code in os.listdir("tests"):
+        if os.path.isfile("tests/" + code):
+            continue
+        compile_badge, test_badge = "", ""
+
+        with open("tmp/extract/tests/" + code + "/info.yml", "r") as stram:
+            info = yaml.load(stram, Loader=yaml.BaseLoader)
+
+        for i in range(len(tested)):
+            compile_badge += (
+                f" [![tested on {tested[i]}](https://img.shields.io/badge/{tested[i]}-"
+            )
+
+            compile_status = info["install_plumed_" + tested[i]]
+            if compile_status == "working":
+                compile_badge += "passing-green.svg"
+            elif compile_status == "broken":
+                compile_badge += "failed-red.svg"
+            else:
+                ValueError(
+                    f"found invalid compilation status for {code} should be 'working' or 'broken', is '{compile_status}'"
+                )
+            compile_badge += ")](tests/" + code + "/install.html)"
+
+            test_badge += (
+                f" [![tested on {tested[i]}](https://img.shields.io/badge/{tested[i]}-"
+            )
+            test_status = info["test_plumed" + tested[i]]
+            if test_status == "working":
+                test_badge += "passing-green.svg"
+            elif test_status == "partial":
+                test_badge += "partial-yellow.svg"
+            elif test_status == "broken":
+                test_badge += "broken-red.svg"
+            elif test_status == "failing":
+                test_badge += "failed-red.svg"
+            if tested[i] != stable_version:
+                test_badge += f")](tests/{code}/testout_{tested[i]}.html)"
+
+            else:
+                test_badge = test_badge + ")](tests/" + code + "/testout.html)"
+        browse += f"| [{code}]({info['link']}) | {info['description']} | {compile_badge} | {test_badge} | \n"
+    browse += " \n"
+    browse += """#### Building PLUMED
+
+When the tests above are run PLUMED is built using the install plumed action.
+```yaml
+- name: Install plumed
+      uses: Iximiel/install-plumed@v1
+      with:
+         CC: "ccache mpicc"
+         CXX: "ccache mpic++"
+         suffix: "${{ steps.get-key.outputs.suffix }}"
+         version: "${{ steps.get-key.outputs.branch }}"
+         extra_options: --enable-boost_serialization --enable-fftw --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH --disable-basic-warnings
+```
+   """
+    # no more necessary
+    # browse+=" \n"
+    # browse+="```bash\n"
+    # sf = open(".ci/install.plumed","r")
+    # inp = sf.read()
+    # for line in inp.splitlines() : f.write( line + "\n")
+    # f.write("```\n")
+    with open("browse.md", "w+") as f:
+        f.write(browse)
 
 
 if __name__ == "__main__":
-   # Check that the workflow matches with the directories
-   checkWorkflow()
-   # Build the page with all the MD codes
-   vf = open("tmp/extract/stable_version.md", "r")
-   stable_version=vf.read()
-   vf.close()  
-   buildBrowsePage( "v"+ stable_version, ("v"+ stable_version,"master") )
+    # Check that the workflow matches with the directories
+    checkWorkflow()
+    # Build the page with all the MD codes
+    vf = open("tmp/extract/stable_version.md", "r")
+    stable_version = vf.read()
+    vf.close()
+    buildBrowsePage("v" + stable_version, ("v" + stable_version, "master"))

--- a/runtests.py
+++ b/runtests.py
@@ -668,7 +668,7 @@ def writeMDReport(
 
         test_result = testOpinion(howbad)
     with open(f"{outdir}/info.yml", "a") as infoOut:
-        infoOut.write(f"test_plumed{version}: {test_result} \n")
+        infoOut.write(f"test_plumed_{version}: {test_result} \n")
 
 
 def writeTermReport(

--- a/runtests.py
+++ b/runtests.py
@@ -633,11 +633,8 @@ def writeMDReport(
         Path(f"./{outdir}").mkdir(parents=True, exist_ok=True)
     ymldata = yamlToDict(f"{basedir}/info.yml", Loader=yaml.BaseLoader)
     info = ymldata["tests"]
-
-    fname = "testout.md"
-
-    if version == "master":
-        fname = "testout_" + version + ".md"
+   
+    fname = "testout_" + version + ".md"
 
     with open(f"{outdir}/{fname}", "w+") as testout:
         testout.write(f"Testing {code}\n")


### PR DESCRIPTION
I also prepended some of the errors with the `raise` keyword to work as intended
And in build.py now there is a more functional way of checking if a test directory exists

I set up a way to get the compiled site in a small artifact to be downloaded at the end of the workflow run
