### PR TITLE
Changing setupInstall to use a template  and info.yml to avoid repeated keywords

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,7 +203,7 @@ jobs:
          echo Running tests for ${{matrix.replica}} with PLUMED from  master branch
          python runtests.py --code=${{matrix.replica}} --version=master
          # Build tarball for upload 
-         tar cf testout.tar tests/${{matrix.replica}}/*.md tests/${{matrix.replica}}/*.yml tests/${{matrix.replica}}/*.zip stable_version.md pages
+         tar cf testout.tar tests/${{matrix.replica}}/*.md tests/${{matrix.replica}}/*.yml tests/${{matrix.replica}}/*.zip pages
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/build.py
+++ b/build.py
@@ -1,4 +1,5 @@
 # formatted with ruff 0.6.4
+from tempfile import template
 import yaml
 import os
 from datetime import date
@@ -89,13 +90,7 @@ def versionSort(list_of_version) -> list:
 def buildBrowsePage():
     print("Building browse page")
 
-    thedate = date.today().strftime("%B %d, %Y")
-    browse = f"""## Browse the tests  
-   
-The codes listed below below were tested on __{thedate}__.
-PLUMED-TESTCENTER tested whether the current and development versions of the code can be used to complete the tests for each of these codes.
-
-
+    table = f"""
 | Name of Program  | Short description | Compiles | Passes tests |
 |:-----------------|:------------------|:--------:|:------------:|
 """
@@ -146,11 +141,9 @@ PLUMED-TESTCENTER tested whether the current and development versions of the cod
                 )
             test_badge += f" [![tested on {version}](https://img.shields.io/badge/{version}-{test_badge_color})](tests/{code}/testout_{version}.html)"
 
-        browse += f"| [{code}]({info['link']}) | {info['description']} | {compile_badge} | {test_badge} | \n"
-    browse += " \n"
-    browse += """#### Building PLUMED
-
-When the tests above are run PLUMED is built using the install plumed action.
+        table += f"| [{code}]({info['link']}) | {info['description']} | {compile_badge} | {test_badge} | \n"
+    
+    plumed_installation_script = """When the tests above are run PLUMED is built using the install plumed action.
 ```yaml
 - name: Install plumed
       uses: Iximiel/install-plumed@v1
@@ -162,16 +155,12 @@ When the tests above are run PLUMED is built using the install plumed action.
          extra_options: --enable-boost_serialization --enable-fftw --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH --disable-basic-warnings
 ```
 """
-    # no more necessary
-    # browse+=" \n"
-    # browse+="```bash\n"
-    # sf = open(".ci/install.plumed","r")
-    # inp = sf.read()
-    # for line in inp.splitlines() : f.write( line + "\n")
-    # f.write("```\n")
-    with open("browse.md", "w+") as f:
-        f.write(browse)
+    with open("template/browse.md", "r") as f:
+        template = f.read()
 
+    thedate = date.today().strftime("%B %d, %Y")
+    with open("browse.md", "w+") as f:
+        f.write(template.format(thedate=thedate, table=table, plumed_installation_script=plumed_installation_script))
 
 if __name__ == "__main__":
     try:

--- a/build.py
+++ b/build.py
@@ -1,5 +1,4 @@
 # formatted with ruff 0.6.4
-from tempfile import template
 import yaml
 import os
 from datetime import date
@@ -90,7 +89,7 @@ def versionSort(list_of_version) -> list:
 def buildBrowsePage():
     print("Building browse page")
 
-    table = f"""
+    table = """
 | Name of Program  | Short description | Compiles | Passes tests |
 |:-----------------|:------------------|:--------:|:------------:|
 """
@@ -101,7 +100,7 @@ def buildBrowsePage():
         compile_badge = ""
         test_badge = ""
         print("processing " + code)
-        with open("tmp/extract/tests/{code}/info.yml", "r") as stream:
+        with open(f"tmp/extract/tests/{code}/info.yml", "r") as stream:
             info = yaml.load(stream, Loader=yaml.BaseLoader)
 
         # sorting the versions
@@ -142,7 +141,7 @@ def buildBrowsePage():
             test_badge += f" [![tested on {version}](https://img.shields.io/badge/{version}-{test_badge_color})](tests/{code}/testout_{version}.html)"
 
         table += f"| [{code}]({info['link']}) | {info['description']} | {compile_badge} | {test_badge} | \n"
-    
+
     plumed_installation_script = """When the tests above are run PLUMED is built using the install plumed action.
 ```yaml
 - name: Install plumed
@@ -160,7 +159,14 @@ def buildBrowsePage():
 
     thedate = date.today().strftime("%B %d, %Y")
     with open("browse.md", "w+") as f:
-        f.write(template.format(thedate=thedate, table=table, plumed_installation_script=plumed_installation_script))
+        f.write(
+            template.format(
+                thedate=thedate,
+                table=table,
+                plumed_installation_script=plumed_installation_script,
+            )
+        )
+
 
 if __name__ == "__main__":
     try:

--- a/build.py
+++ b/build.py
@@ -110,7 +110,8 @@ PLUMED-TESTCENTER tested whether the current and development versions of the cod
             info = yaml.load(stream, Loader=yaml.BaseLoader)
 
         # sorting the versions
-        tested = versionSort(info["install_plumed"].keys())
+        results = info["results"]
+        tested = versionSort(results.keys())
 
         for version in tested:
             # building the compilation badge
@@ -118,14 +119,14 @@ PLUMED-TESTCENTER tested whether the current and development versions of the cod
                 f" [![tested on {version}](https://img.shields.io/badge/{version}-"
             )
 
-            compile_status = info["install_plumed"][version]
+            compile_status = results[version]["install_plumed"]
             if compile_status == "working":
                 compile_badge += "passing-green.svg"
             elif compile_status == "broken":
                 compile_badge += "failed-red.svg"
             else:
                 raise ValueError(
-                    f"found invalid compilation status for {code}['install_plumed']['{version}'] should be 'working' or 'broken', is '{compile_status}'"
+                    f"found invalid compilation status for {code} with {version} should be 'working' or 'broken', is '{compile_status}'"
                 )
             compile_badge += ")](tests/" + code + "/install.html)"
 
@@ -133,7 +134,7 @@ PLUMED-TESTCENTER tested whether the current and development versions of the cod
             test_badge += (
                 f" [![tested on {version}](https://img.shields.io/badge/{version}-"
             )
-            test_status = info["test_plumed"][version]
+            test_status = results[version]["test_plumed"]
 
             if test_status == "working":
                 test_badge += "passing-green.svg"
@@ -145,7 +146,7 @@ PLUMED-TESTCENTER tested whether the current and development versions of the cod
                 test_badge += "failed-red.svg"
             else:
                 raise ValueError(
-                    f"found invalid test status for {code}['test_plumed']['{version}'] should be 'working', 'partial', 'failing' or 'broken', is '{test_status}'"
+                    f"found invalid test status for {code} with {version} should be 'working', 'partial', 'failing' or 'broken', is '{test_status}'"
                 )
             test_badge += f")](tests/{code}/testout_{version}.html)"
 

--- a/build.py
+++ b/build.py
@@ -106,7 +106,7 @@ PLUMED-TESTCENTER tested whether the current and development versions of the cod
         compile_badge = ""
         test_badge = ""
         print("processing " + code)
-        with open("tmp/extract/tests/" + code + "/info.yml", "r") as stream:
+        with open("tmp/extract/tests/{code}/info.yml", "r") as stream:
             info = yaml.load(stream, Loader=yaml.BaseLoader)
 
         # sorting the versions
@@ -115,40 +115,36 @@ PLUMED-TESTCENTER tested whether the current and development versions of the cod
 
         for version in tested:
             # building the compilation badge
-            compile_badge += (
-                f" [![tested on {version}](https://img.shields.io/badge/{version}-"
-            )
 
             compile_status = results[version]["install_plumed"]
             if compile_status == "working":
-                compile_badge += "passing-green.svg"
+                compile_badge_color = "passing-green.svg"
             elif compile_status == "broken":
-                compile_badge += "failed-red.svg"
+                compile_badge_color = "failed-red.svg"
             else:
                 raise ValueError(
                     f"found invalid compilation status for {code} with {version} should be 'working' or 'broken', is '{compile_status}'"
                 )
-            compile_badge += ")](tests/" + code + "/install.html)"
+
+            compile_badge += f" [![tested on {version}](https://img.shields.io/badge/{version}-{compile_badge_color})](tests/{code}/install.html)"
 
             # building the tests badge
-            test_badge += (
-                f" [![tested on {version}](https://img.shields.io/badge/{version}-"
-            )
+
             test_status = results[version]["test_plumed"]
 
             if test_status == "working":
-                test_badge += "passing-green.svg"
+                test_badge_color = "passing-green.svg"
             elif test_status == "partial":
-                test_badge += "partial-yellow.svg"
-            elif test_status == "broken":
-                test_badge += "broken-36454F.svg"
+                test_badge_color = "partial-yellow.svg"
             elif test_status == "failing":
-                test_badge += "failed-red.svg"
+                test_badge_color = "failed-red.svg"
+            elif test_status == "broken":
+                test_badge_color = "broken-36454F.svg"
             else:
                 raise ValueError(
                     f"found invalid test status for {code} with {version} should be 'working', 'partial', 'failing' or 'broken', is '{test_status}'"
                 )
-            test_badge += f")](tests/{code}/testout_{version}.html)"
+            test_badge += f" [![tested on {version}](https://img.shields.io/badge/{version}-{test_badge_color})](tests/{code}/testout_{version}.html)"
 
         browse += f"| [{code}]({info['link']}) | {info['description']} | {compile_badge} | {test_badge} | \n"
     browse += " \n"

--- a/build.py
+++ b/build.py
@@ -154,7 +154,7 @@ def buildBrowsePage():
          extra_options: --enable-boost_serialization --enable-fftw --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH --disable-basic-warnings
 ```
 """
-    with open("template/browse.md", "r") as f:
+    with open("templates/browse.md", "r") as f:
         template = f.read()
 
     thedate = date.today().strftime("%B %d, %Y")

--- a/localrun.py
+++ b/localrun.py
@@ -78,5 +78,9 @@ if __name__ == "__main__":
         )
         exit(1)
     except Exception as e:
+        import traceback
+
+        traceback.print_exc()
+        print("Error: ", type(e))
         print(e)
         exit(1)

--- a/runtests.py
+++ b/runtests.py
@@ -130,6 +130,7 @@ def buildTestPages(
 ):
     for page in os.listdir(directory):
         if ".md" in page:
+            print(f"Processing {directory}/{page}")
             processMarkdown(directory + "/" + page, prefix, runSettings, overwrite)
 
 
@@ -663,10 +664,13 @@ def writeMDReport(
 
         test_result = testOpinion(howbad)
     ymldata = yamlToDict(f"{basedir}/info.yml", Loader=yaml.SafeLoader)
-    if "test_plumed" in ymldata.keys():
-        ymldata["test_plumed"][str(version)] = test_result
+    if "results" not in ymldata.keys():
+        ymldata["results"] = {}
+    str_version = str(version)
+    if str_version in ymldata["results"].keys():
+        ymldata["results"][str_version]["test_plumed"] = test_result
     else:
-        ymldata["test_plumed"] = {str(version): test_result}
+        ymldata["results"][str_version] = {"test_plumed": test_result}
     with open(f"{outdir}/info.yml", "w") as infoOut:
         infoOut.write(yaml.dump(ymldata, sort_keys=False))
 

--- a/setupInstall.py
+++ b/setupInstall.py
@@ -1,6 +1,5 @@
 import os
 import getopt
-import subprocess
 from zipfile import ZipFile
 
 
@@ -27,14 +26,6 @@ def zip_and_remove(myzipfile, paths):
 
 
 def buildInstallPage(code):
-    stable_version = (
-        subprocess.check_output("plumed info --version", shell=True)
-        .decode("utf-8")
-        .strip()
-    )
-    # Save the stable version of plumed to a file to pass to the update.py script (not classy Gareth)
-    with open("stable_version.md", "w+") as vf:
-        vf.write(stable_version)
     # Zip all the logs
     zip_and_remove(
         f"tests/{code}/stable_output.zip",

--- a/setupInstall.py
+++ b/setupInstall.py
@@ -1,54 +1,73 @@
 import os
-import sys
 import getopt
 import subprocess
-import zipfile
+from zipfile import ZipFile
 
-def zip(path):
-    """ Zip a path removing the original file """
-    with zipfile.ZipFile(path + ".zip", "w") as f_out:
-        f_out.write(path)
-    # I need the file in the ouput
-    os.remove(path)
 
-def buildInstallPage( code ) :
-   # Zip all the logs
-   zip("tests/" + code + "/stdout.txt")
-   zip("tests/" + code + "/stderr.txt")
-   zip("tests/" + code + "/stdout_master.txt")
-   zip("tests/" + code + "/stderr_master.txt")
-   of = open( "tests/" + code + "/install.md", "w+" )
-   of.write("Compiling " + code + "\n")
-   of.write("------------------------\n \n")
-   stable_version=subprocess.check_output('plumed info --version', shell=True).decode('utf-8').strip()
-   # Save the stable version of plumed to a file to pass to the update.py script (not classy Gareth)
-   with open("stable_version.md", "w+") as vf:
-    vf.write( stable_version )
-   
-   of.write("To compile " + code + " and PLUMED the following bash script was used.  " + code + " was statically linked with the v" + stable_version + " of PLUMED. In a separate build, the master version of PLUMED was linked to " + code + " as a runtime library. \n \n")
-   of.write("Build with stable version download: [zipped raw stdout](stdout.txt.zip)  - [zipped raw stderr](stderr.txt.zip) \n \n")
-   of.write("Build with master version download: [zipped raw stdout](stdout_master.txt.zip)  - [zipped raw stderr](stderr_master.txt.zip) \n\n")
-   of.write("```bash\n")
+def zip_and_remove(myzipfile, paths):
+    """
+    Compresses the specified files into a zip archive and removes the original files.
 
-   with open("tests/" + code + "/install.sh", "r") as sf:   
-    inp = sf.read()
-    for line in inp.splitlines() :
-        of.write( line + "\n")
-   of.write("```\n\n")
-   of.close()
+    Args:
+        myzipfile (str): The path to the zip file to be created.
+        paths (list): A list of file paths to be compressed and removed.
+
+    The function compresses the files at the specified paths into a zip archive
+    located at 'myzipfile'. Each file is added to the archive without its directory path,
+    resulting in all files being located at the root of the zip archive. After each file
+    is added to the archive, it is removed from the file system.
+    """
+    with ZipFile(myzipfile, "w") as f_out:
+        for path in paths:
+            # a text file can ve compressed with maximum compression effor without problems
+            nopathfile = path.split("/")[-1]
+            # with removing the path of the file the files will be compressed in the "home" of the zip (with less clicks to check)
+            f_out.write(path, arcname=nopathfile, compresslevel=9)
+            os.remove(path)
+
+
+def buildInstallPage(code):
+    stable_version = (
+        subprocess.check_output("plumed info --version", shell=True)
+        .decode("utf-8")
+        .strip()
+    )
+    # Save the stable version of plumed to a file to pass to the update.py script (not classy Gareth)
+    with open("stable_version.md", "w+") as vf:
+        vf.write(stable_version)
+    # Zip all the logs
+    zip_and_remove(
+        f"tests/{code}/stable_output.zip",
+        [f"tests/{code}/stdout.txt", f"tests/{code}/stderr.txt"],
+    )
+    zip_and_remove(
+        f"tests/{code}/master_output.zip",
+        [f"tests/{code}/stdout_master.txt", f"tests/{code}/stderr_master.txt"],
+    )
+
+    with open("templates/install.md", "r") as templatefile:
+        template = templatefile.read()
+    with open(f"tests/{code}/install.sh", "r") as sf:
+        script = sf.read()
+
+    with open(f"tests/{code}/install.md", "w+") as of:
+        of.write(template.format(code=code, script=script))
+
 
 if __name__ == "__main__":
-   code, argv = "", sys.argv[1:]
-   try:
-     opts, args = getopt.getopt(argv,"hc:",["code="])
-   except:
-       print('setupInstall.py -c <code>')
+    import sys
 
-   for opt, arg in opts:
-       if opt in ['-h'] :
-          print('setupInstall.py -c <code>')
-          sys.exit()
-       elif opt in ["-c", "--code"]:
-          code = arg
-   # Setup compile page
-   buildInstallPage(code)
+    code, argv = "", sys.argv[1:]
+    try:
+        opts, args = getopt.getopt(argv, "hc:", ["code="])
+    except Exception as _:
+        print("setupInstall.py -c <code>")
+
+    for opt, arg in opts:
+        if opt in ["-h"]:
+            print("setupInstall.py -c <code>")
+            sys.exit()
+        elif opt in ["-c", "--code"]:
+            code = arg
+    # Setup compile page
+    buildInstallPage(code)

--- a/templates/browse.md
+++ b/templates/browse.md
@@ -1,0 +1,12 @@
+## Browse the tests  
+   
+The codes listed below below were tested on __{thedate}__.
+PLUMED-TESTCENTER tested whether the current and development versions of the code can be used to complete the tests for each of these codes.
+
+
+{table}
+
+
+#### Building PLUMED
+
+{plumed_installation_script}

--- a/templates/install.md
+++ b/templates/install.md
@@ -1,0 +1,13 @@
+## Compiling {code}
+
+To compile {code} and PLUMED the following bash script was used.
+{code} was statically linked with the v" + stable_version + " of PLUMED.
+In a separate build, the master version of PLUMED was linked to {code} as a runtime library.
+
+Build with stable version download: [zipped raw stdout and stderr](stable_output.zip)
+
+Build with master version download: [zipped raw stdout and stderr](master_output.zip)
+
+```bash
+{script}
+```

--- a/tests/check_status.sh
+++ b/tests/check_status.sh
@@ -27,7 +27,7 @@ echo -n "Looking for executable ${executible_suffixed} or ${executible}..."
 suffix=${suffix/_/}
 if [[ -x $executible ]] || [[ -x $executible_suffixed ]]; then
 
-     python updateYaml.py "$info_yml" "install_plumed" "${suffix}" working
+     python updateYaml.py "$info_yml" results "${suffix}" "install_plumed" working
      if [[ -x $executible_suffixed ]]; then
           echo "found $executible_suffixed"
           # the install script should have done the homework (see below)
@@ -52,4 +52,4 @@ else
 fi
 echo "Something is wrong with the installation of the patched $code with plumed$suffix"
 
-python updateYaml.py "$info_yml" "install_plumed" "${suffix}" broken
+python updateYaml.py "$info_yml" results "${suffix}" "install_plumed" broken


### PR DESCRIPTION
I think having templates makes some part of the most wordy md files easier to set up/change and to control their syntax

I removed the need to store the `stable_version.md`, since there is no more use of knowing if `testout.md` comes from the stable or from master since both have `_master` or `_version` now