### PR TITLE
this should solve the duplication of the css and the js files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,8 +209,6 @@ jobs:
           **/tests/${{matrix.replica}}/*.yml
           **/tests/${{matrix.replica}}/*.zip
           **/tests/${{matrix.replica}}/*.png
-          **/tests/${{matrix.replica}}/*.js
-          **/tests/${{matrix.replica}}/*.css
         retention-days: 1
         # is more or less only text (or compressed text)
         compression-level: 9
@@ -223,6 +221,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+        cache: 'pip'
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
@@ -231,10 +234,11 @@ jobs:
         merge-multiple: true
     - name: Prepare for upload
       run: |
+        pip install -r requirements.txt
         # This builds the page with the results of the tests
         python build.py
         # This pushes everything to the final website 
-        bash .ci/prepare _config.yml _layouts _data assets pigeon.png plumed.md nest.png contribute.md browse.md Info.md treadmill.png
+        bash .ci/prepare _config.yml _layouts _data assets js pigeon.png plumed.md nest.png contribute.md browse.md Info.md treadmill.png
   
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v4

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#157878">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <link rel="stylesheet" href="plumedtohtml.css">
+    <link rel="stylesheet" href="{{ '/assets/css/plumedtohtml.css | relative_url }}">
 	{% if page.url == "/browse.html" or page.url == "/summary.html"%}
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 	<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jszip-2.5.0/dt-1.10.18/b-1.5.6/b-flash-1.5.6/b-html5-1.5.6/datatables.min.css"/>
@@ -25,7 +25,7 @@
         }
       });
     </script>
-  <script type="text/javascript" src="plumedtohtml.js"></script>
+  <script type="text/javascript" src="{{ '/js/plumedtohtml.js | relative_url }}"></script>
   <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.1.7/mermaid.min.js"></script>
   </head>

--- a/build.py
+++ b/build.py
@@ -169,7 +169,22 @@ def buildBrowsePage():
 
 
 if __name__ == "__main__":
+    from PlumedToHTML import (
+        get_css as PlumedToHTML_css,
+        get_javascript as PlumedToHTML_js,
+    )
+    from pathlib import Path
+
     try:
+        # this puts the assets in the right places:
+
+        Path(f"./js/").mkdir(parents=True, exist_ok=True)
+        # Print the js for plumedToHTML to a file
+        with open(f"./js/plumedtohtml.js", "w+") as jf:
+            jf.write(PlumedToHTML_js())
+        with open(f"./assets/css/plumedtohtml.css", "w+") as jf:
+            jf.write(PlumedToHTML_css())
+
         # Check that the workflow matches with the directories
         checkWorkflow()
 

--- a/runtests.py
+++ b/runtests.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from MDAnalysis.coordinates.XYZ import XYZReader
 from datetime import date
 from contextlib import contextmanager
-from PlumedToHTML import test_plumed, get_html, get_javascript, get_css
+from PlumedToHTML import test_plumed, get_html
 from runhelper import (
     writeReportForSimulations,
     dictToReport,
@@ -54,15 +54,7 @@ def processMarkdown(
     # creates the directory, if it doesn't exist
     directory = os.path.dirname(destination)
     Path(f"./{directory}").mkdir(parents=True, exist_ok=True)
-    if overwrite or not Path(f"./{directory}/plumedtohtml.js").exists() :
-       # Print the js for plumedToHTML to a file
-       with open(f"./{directory}/plumedtohtml.js", "w+") as jf : jf.write( get_javascript() )
-    if overwrite or not Path(f"./{directory}/plumedtohtml.css").exists() :
-       # Print the css for plumedToHTML to a file
-       with open(f"./{directory}/plumedtohtml.css", "w+") as jf : jf.write( get_css() )
-    if not overwrite and Path(destination).exists():
-        return
-
+    
     processed = ""
     inplumed = False
     plumed_inp = ""


### PR DESCRIPTION
I think I found the solution to the problem I pointed this morning (i the tutorials)

I moved the creation of the css and js files into build that puts them directly in the wanted place

I copied how `asset/style.css` is referred in the `layout_/default.html`  let's see if this is working

If we write only these two file, we should have less things to forgot and to move around :)

I mostly moved the code around and eliminated the few lines to copy css and js in the artifact, unless there are no other js and css files this should not make damage.

I am setting up the PR to see if the CI works and to look at the "debug artifact"